### PR TITLE
Don't update a draft when on the `/drafts/editor` route

### DIFF
--- a/src/app/drafts/containers/editor-container/editor-container.component.html
+++ b/src/app/drafts/containers/editor-container/editor-container.component.html
@@ -4,6 +4,5 @@
 </div>
 
 <ng-template #noDraftProvided>
-  <app-editor [authState]="authState$ | async" [broadcastState]="broadcastState$ | async" (formChanges)="updateDraft($event)"
-    (formSubmit)="broadcastDraft($event)"></app-editor>
+  <app-editor [authState]="authState$ | async" [broadcastState]="broadcastState$ | async" (formSubmit)="broadcastDraft($event)"></app-editor>
 </ng-template>


### PR DESCRIPTION
- when no template provided to the *EditorContainer* (thus when creating a post via the */drafts/editor* route), the draft is not anymore created and updated

Fixes #16 