### PR TITLE
Fix a bug with broadcasting when there are no beneficiaries

### DIFF
--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -94,7 +94,9 @@ export const steemizeDraft = (draft: Draft, token: OAuth2Token) => {
   const imagesWithThumbnail = draft.thumbnailUrl
     ? [draft.thumbnailUrl, ...images]
     : [...images];
-  const extensions = createExtensionsOfBeneficiaries(draft.beneficiaries);
+  const extensions = draft.beneficiaries.length
+    ? createExtensionsOfBeneficiaries(draft.beneficiaries)
+    : [];
 
   return [
     [


### PR DESCRIPTION
- added a condition whether there are beneficiaries in the draft so proper `extensions` can be set up

Fixes #17 