### PR TITLE
Create reusable Editor NgModule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -688,6 +688,11 @@
         "@types/jasmine": "*"
       }
     },
+    "@types/marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-xkURX55US18wHme+O2UlqJf3Fo7FqT5VAL+OJ/zK+jP2NX57naryDHoiqt/pMIwZjDc62sRvXUWuQQxQiBdheQ=="
+    },
     "@types/node": {
       "version": "6.0.106",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.106.tgz",
@@ -2198,6 +2203,17 @@
         "source-map": "0.5.x"
       }
     },
+    "clipboard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz",
+      "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -2952,6 +2968,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -4698,6 +4720,15 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.4",
         "minimatch": "~3.0.2"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -7199,6 +7230,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -7551,6 +7587,17 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ngx-cookie/-/ngx-cookie-3.0.1.tgz",
       "integrity": "sha1-UPMzXVeKl2SQLPoNkMzLp/DzM50="
+    },
+    "ngx-markdown": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-6.1.0.tgz",
+      "integrity": "sha512-+EiFsX9wcOzroaSMLWgY84uvZWxslnGKoBw34l4ZJMmoPUFDQGET5H3MB4PstGMaGlwVO03r2DuXH+/EqBUuqA==",
+      "requires": {
+        "@types/marked": "^0.4.0",
+        "marked": "^0.4.0",
+        "prismjs": "^1.14.0",
+        "tslib": "^1.9.0"
+      }
     },
     "no-case": {
       "version": "2.3.2",
@@ -8650,6 +8697,14 @@
         "utila": "~0.4"
       }
     },
+    "prismjs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
+      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -9619,6 +9674,12 @@
           }
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -10594,6 +10655,12 @@
       "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
       "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
       "dev": true,
+      "optional": true
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
       "optional": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "hammerjs": "^2.0.8",
     "idb": "^2.1.1",
     "ngx-cookie": "^3.0.1",
+    "ngx-markdown": "^6.1.0",
     "ramda": "^0.25.0",
     "rxjs": "^6.1.0",
     "speakingurl": "^14.0.1",

--- a/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.html
+++ b/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.html
@@ -1,0 +1,51 @@
+<div [formGroup]="parentForm">
+  <mat-card class="beneficiaries__card">
+    <mat-toolbar>
+      <span>Beneficiaries
+        <sup matTooltip="Beneficiary is an account which receives a part of the post's reward" matTooltipPosition="right">
+          <mat-icon color="primary">info</mat-icon>
+        </sup>
+      </span>
+      <span class="spacer"></span>
+      <button mat-mini-fab color="accent" [disabled]="totalBeneficiaries >= 8" (click)="addBeneficiary()" class="beneficiaries__add-button">
+        <mat-icon>add</mat-icon>
+      </button>
+    </mat-toolbar>
+
+    <div class="beneficiaries__container">
+      <div formArrayName="beneficiaries" *ngFor="let beneficiary of beneficiariesFormArray.controls; let i = index;">
+        <div [formGroupName]="i" fxLayout fxLayoutGap="10" fxLayoutAlign="space-between center" class="beneficiary">
+          <div fxFlex="30" class="beneficiary__item beneficiary__item--left">
+            <mat-form-field class="beneficiary__field">
+              <input matInput [errorStateMatcher]="alwaysMatcher" formControlName="account" type="text" placeholder="Account" class="beneficiary__input">
+              <mat-error *ngIf="getBeneficiaryAccountControl(i)?.hasError('required')" class="beneficiary__error beneficiary__error--required">{{ errorMessages.required }}</mat-error>
+              <mat-error *ngIf="getBeneficiaryAccountControl(i)?.hasError('pattern')" class="beneficiary__error beneficiary__error--pattern">{{ errorMessages.pattern }}</mat-error>
+            </mat-form-field>
+          </div>
+          <div fxFlex="40" class="beneficiary__item beneficiary__item--center">
+            <mat-slider formControlName="weight" mix="0" max="100" step="1" thumbLabel [displayWith]="formatSliderThumbLabel" class="beneficiary__slider"></mat-slider>
+          </div>
+          <div fxFlex="10" class="beneficiary__item beneficiary__item--right">
+            <button mat-icon-button (click)="removeBeneficiary(i)" class="beneficiary__remove-button">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
+        </div>
+        <mat-divider></mat-divider>
+      </div>
+
+      <div *ngIf="hasBeneficiariesFormArrayErrors" class="beneficiaries__errors">
+        <mat-error *ngIf="beneficiariesFormArray.hasError('tooHighWeight')" class="beneficiaries__error beneficiaries__error--too-high-weight">{{errorMessages.tooHighWeight}}</mat-error>
+        <mat-error *ngIf="beneficiariesFormArray.hasError('tooManyBeneficiaries')" class="beneficiaries__error beneficiaries__error--too-many-beneficiaries">{{errorMessages.tooManyBeneficiaries}}</mat-error>
+        <mat-error *ngIf="beneficiariesFormArray.hasError('notUniqueNames')" class="beneficiaries__error beneficiaries__error--not-unique-names">{{errorMessages.notUniqueNames}}</mat-error>
+      </div>
+
+      <mat-divider *ngIf="hasBeneficiariesFormArrayErrors"></mat-divider>
+
+      <div fxLayout fxLayoutAlign="space-between center" class="beneficiaries__summary">
+        <div fxFlex class="mat-body-2 beneficiaries__summary-total-weight">Total: {{ totalBeneficiariesWeight }}%</div>
+        <div fxFlex class="mat-body-2 beneficiaries__summary-total-beneficiaries">{{totalBeneficiaries}}/8</div>
+      </div>
+    </div>
+  </mat-card>
+</div>

--- a/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.scss
+++ b/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.scss
@@ -1,0 +1,40 @@
+.beneficiaries__card {
+  margin: 0;
+  padding: 0;
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+.beneficiaries__container {
+  padding: 0 30px;
+}
+
+.beneficiary {
+  padding: 20px 0;
+}
+
+.beneficiary__field {
+  width: 100%;
+}
+
+.beneficiary__slider {
+  width: 100%;
+}
+
+.beneficiary__item--right {
+  text-align: right;
+}
+
+.beneficiaries__errors {
+  padding: 15px 0;
+}
+
+.beneficiaries__summary {
+  padding: 10px 0;
+}
+
+.beneficiaries__summary-total-beneficiaries {
+  text-align: right;
+}

--- a/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.spec.ts
+++ b/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.spec.ts
@@ -1,0 +1,353 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  ViewChild
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  AbstractControl,
+  FormArray,
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { always } from 'ramda';
+import { EditorMaterialModule } from '../../editor-material/editor-material.module';
+import { beneficiariesCustomValidators } from '../../validators/beneficiaries.validators';
+import { BeneficiariesPartialFormComponent } from './beneficiaries-partial-form.component';
+
+@Component({
+  selector: `app-host-component`,
+  template: `<app-beneficiaries-partial-form [parentForm]="parentForm"></app-beneficiaries-partial-form>`
+})
+class TestHostComponent {
+  @ViewChild(BeneficiariesPartialFormComponent)
+  beneficiariesPartialFormComponent: BeneficiariesPartialFormComponent;
+
+  parentForm: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      beneficiaries: this.formBuilder.array([], beneficiariesCustomValidators)
+    });
+  }
+}
+
+fdescribe('#EditorModule BeneficiariesPartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: BeneficiariesPartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, BeneficiariesPartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(BeneficiariesPartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.beneficiariesPartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('#beneficiariesFormArray should be pointing on `parentForm.controls.beneficiaries`', () => {
+    expect(component.beneficiariesFormArray).toBe(component.parentForm.controls
+      .beneficiaries as FormArray);
+  });
+
+  it('#hasBeneficiariesFormArrayErrors should return false if `beneficiariesFormArray` doesnt have any errors', () => {
+    component.beneficiariesFormArray.setErrors(null);
+
+    expect(component.hasBeneficiariesFormArrayErrors).toBeFalsy();
+  });
+
+  it('#hasBeneficiariesFormArrayErrors should return true if `beneficiariesFormArray` has any errors', () => {
+    component.beneficiariesFormArray.setErrors({ errTest: true });
+
+    expect(component.hasBeneficiariesFormArrayErrors).toBeTruthy();
+  });
+
+  it('#totalBeneficiariesWeight should be equal to sum of all beneficiaires weights', () => {
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.beneficiariesFormArray.controls[0].setValue({
+      account: 'jakipatryk',
+      weight: 10
+    });
+    component.beneficiariesFormArray.controls[1].setValue({
+      account: 'jakipatryk-pl',
+      weight: 20
+    });
+
+    expect(component.totalBeneficiariesWeight).toEqual(30);
+  });
+
+  it('#totalBeneficiaries should be equal to a number of all beneficiaries', () => {
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.beneficiariesFormArray.controls[0].setValue({
+      account: 'jakipatryk',
+      weight: 10
+    });
+    component.beneficiariesFormArray.controls[1].setValue({
+      account: 'jakipatryk-pl',
+      weight: 20
+    });
+
+    expect(component.totalBeneficiaries).toEqual(2);
+  });
+
+  it('#addBeneficiary should add a new beneficiary to the `beneficiariesFormArray', () => {
+    component.beneficiariesFormArray.setValue([]);
+
+    component.addBeneficiary();
+
+    expect(component.beneficiariesFormArray.value.length).toBeGreaterThan(0);
+    expect(
+      component.beneficiariesFormArray.controls[0].value.account
+    ).toBeDefined();
+    expect(
+      component.beneficiariesFormArray.controls[0].value.weight
+    ).toBeDefined();
+  });
+
+  it('#formatSliderThumbLabel should add a "%" to the value', () => {
+    const value = 10;
+    let formattedValue: string;
+
+    formattedValue = component.formatSliderThumbLabel(value);
+
+    expect(formattedValue).toBe('10%');
+  });
+
+  it('#getBeneficiaryAccountControl should return a `FormControl` of a beneficiary of a given index if it exists', () => {
+    let beneficiaryAccountControl: AbstractControl;
+
+    component.beneficiariesFormArray.setValue([]);
+    component.addBeneficiary();
+    beneficiaryAccountControl = component.getBeneficiaryAccountControl(0);
+
+    expect(beneficiaryAccountControl).toBeDefined();
+  });
+
+  it('#getBeneficiaryAccountControl should return a `undefined` if a beneficiary of a given index does NOT exist', () => {
+    let beneficiaryAccountControl: AbstractControl;
+
+    component.beneficiariesFormArray.setValue([]);
+    beneficiaryAccountControl = component.getBeneficiaryAccountControl(0);
+
+    expect(beneficiaryAccountControl).toBeUndefined();
+  });
+
+  it('#removeBeneficiary should remove a beneficiary of a given index from `beneficiariesFormArray`', () => {
+    component.beneficiariesFormArray.setValue([]);
+    component.addBeneficiary();
+    component.removeBeneficiary(0);
+
+    expect(component.beneficiariesFormArray.controls[0]).toBeUndefined();
+  });
+
+  it('(.beneficiaries__errors) should be rendered if `beneficiariesFormArray` has errors', () => {
+    let beneficiariesErrorsElement: DebugElement;
+
+    component.beneficiariesFormArray.setErrors({ testError: true });
+    hostFixture.detectChanges();
+    beneficiariesErrorsElement = hostFixture.debugElement.query(
+      By.css('.beneficiaries__errors')
+    );
+
+    expect(beneficiariesErrorsElement.nativeElement).toBeDefined();
+  });
+
+  it('(.beneficiaries__errors) should NOT be rendered if `beneficiariesFormArray` doesnt have errors', () => {
+    let beneficiariesErrorsElement: DebugElement;
+
+    component.beneficiariesFormArray.setErrors(null);
+    hostFixture.detectChanges();
+    beneficiariesErrorsElement = hostFixture.debugElement.query(
+      By.css('.beneficiaries__errors')
+    );
+
+    expect(beneficiariesErrorsElement).toEqual(null);
+  });
+
+  it('(.beneficiaries__add-button) should be enabled if there are less than 8 beneficiaries', () => {
+    const getBeneficiariesAddButton: () => DebugElement = always(
+      hostFixture.debugElement.query(By.css('.beneficiaries__add-button'))
+    );
+    expect(getBeneficiariesAddButton().nativeElement.disabled).toBeFalsy();
+
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    hostFixture.detectChanges();
+
+    expect(getBeneficiariesAddButton().nativeElement.disabled).toBeFalsy();
+  });
+
+  it('(.beneficiaries__add-button) should be disabled if there are more than or equal 8 beneficiaries', () => {
+    const getBeneficiariesAddButton: () => DebugElement = always(
+      hostFixture.debugElement.query(By.css('.beneficiaries__add-button'))
+    );
+
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    component.addBeneficiary();
+    hostFixture.detectChanges();
+
+    expect(getBeneficiariesAddButton().nativeElement.disabled).toBeTruthy();
+
+    component.addBeneficiary();
+    hostFixture.detectChanges();
+
+    expect(getBeneficiariesAddButton().nativeElement.disabled).toBeTruthy();
+  });
+
+  it('(.beneficiaries__add-button click) should add a new `.beneficiary`', () => {
+    let beneficiaryElement: DebugElement;
+
+    component.beneficiariesFormArray.setValue([]);
+    hostFixture.debugElement
+      .query(By.css('.beneficiaries__add-button'))
+      .triggerEventHandler('click', null);
+    hostFixture.detectChanges();
+    beneficiaryElement = hostFixture.debugElement.query(By.css('.beneficiary'));
+
+    expect(beneficiaryElement.nativeElement).toBeDefined();
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.beneficiaries__error--too-high-weight) should be rendered with a correct message if `beneficiariesFormArray` has error `tooHighWeight', () => {
+    let errorElement: DebugElement;
+
+    component.beneficiariesFormArray.setErrors({ tooHighWeight: true });
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.beneficiaries__error--too-high-weight')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.tooHighWeight
+    );
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.beneficiaries__error--too-many-beneficiaries) should be rendered with a correct message if `beneficiariesFormArray` has error `tooManyBeneficiaries', () => {
+    let errorElement: DebugElement;
+
+    component.beneficiariesFormArray.setErrors({ tooManyBeneficiaries: true });
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.beneficiaries__error--too-many-beneficiaries')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.tooManyBeneficiaries
+    );
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.beneficiaries__error--not-unique-names) should be rendered with a correct message if `beneficiariesFormArray` has error `notUniqueNames', () => {
+    let errorElement: DebugElement;
+
+    component.beneficiariesFormArray.setErrors({ notUniqueNames: true });
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.beneficiaries__error--not-unique-names')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.notUniqueNames
+    );
+  });
+
+  it('(.beneficiary__remove-button click) should remove a `.beneficiary`', () => {
+    let beneficiaryRemoveButton: DebugElement;
+    let beneficiaryElement: DebugElement;
+
+    component.beneficiariesFormArray.setValue([]);
+    component.addBeneficiary();
+    hostFixture.detectChanges();
+    beneficiaryRemoveButton = hostFixture.debugElement.query(
+      By.css('.beneficiary__remove-button')
+    );
+    beneficiaryRemoveButton.triggerEventHandler('click', null);
+    hostFixture.detectChanges();
+    beneficiaryElement = hostFixture.debugElement.query(By.css('.beneficiary'));
+
+    expect(beneficiaryElement).toEqual(null);
+  });
+
+  it('(.beneficiaries__summary-total-weight) should render text which contains `totalBeneficiariesWeight`', () => {
+    const getBeneficiariesSummaryTotalWeightElement: () => DebugElement = always(
+      hostFixture.debugElement.query(
+        By.css('.beneficiaries__summary-total-weight')
+      )
+    );
+
+    expect(
+      getBeneficiariesSummaryTotalWeightElement().nativeElement.innerText
+    ).toContain(component.totalBeneficiariesWeight);
+
+    component.addBeneficiary();
+    component
+      .getBeneficiaryAccountControl(0)
+      .setValue({ account: 'jakipatryk', weight: 15 });
+    hostFixture.detectChanges();
+
+    expect(
+      getBeneficiariesSummaryTotalWeightElement().nativeElement.innerText
+    ).toContain(component.totalBeneficiariesWeight);
+  });
+
+  it('(.beneficiaries__summary-total-beneficiaries) should render text which contains `totalBeneficiaries`', () => {
+    const getBeneficiariesSummaryTotalBeneficiariesElement: () => DebugElement = always(
+      hostFixture.debugElement.query(
+        By.css('.beneficiaries__summary-total-beneficiaries')
+      )
+    );
+
+    expect(
+      getBeneficiariesSummaryTotalBeneficiariesElement().nativeElement.innerText
+    ).toContain(component.totalBeneficiaries);
+
+    component.addBeneficiary();
+    hostFixture.detectChanges();
+
+    expect(
+      getBeneficiariesSummaryTotalBeneficiariesElement().nativeElement.innerText
+    ).toContain(component.totalBeneficiaries);
+  });
+});

--- a/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.ts
+++ b/src/app/editor/components/beneficiaries-partial-form/beneficiaries-partial-form.component.ts
@@ -1,0 +1,97 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  Validators
+} from '@angular/forms';
+import {
+  add,
+  either,
+  isEmpty,
+  isNil,
+  map,
+  not,
+  path,
+  pipe,
+  prop,
+  reduce
+} from 'ramda';
+import { AlwaysMatcher } from './../../matchers/always.matcher';
+
+@Component({
+  selector: 'app-beneficiaries-partial-form',
+  templateUrl: './beneficiaries-partial-form.component.html',
+  styleUrls: ['./beneficiaries-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BeneficiariesPartialFormComponent {
+  @Input() parentForm: FormGroup;
+
+  alwaysMatcher = new AlwaysMatcher();
+
+  readonly errorMessages = {
+    pattern: 'Please type a valid username!',
+    required: 'Account is required!',
+    // tslint:disable-next-line:quotemark
+    tooManyBeneficiaries: "You can't set more than 8 beneficiaries!",
+    tooHighWeight:
+      // tslint:disable-next-line:quotemark
+      "You can't allocate more than 100% of reward to beneficiaries!",
+    // tslint:disable-next-line:quotemark
+    notUniqueNames:
+      // tslint:disable-next-line:quotemark
+      "You can't set the same beneficiary more than once for a given post!"
+  };
+
+  get beneficiariesFormArray(): FormArray {
+    return this.parentForm.get('beneficiaries') as FormArray;
+  }
+
+  get hasBeneficiariesFormArrayErrors(): boolean {
+    return pipe(
+      either(isEmpty, isNil),
+      not
+    )(this.beneficiariesFormArray.errors);
+  }
+
+  get totalBeneficiariesWeight(): number {
+    return pipe(
+      map(prop('weight')),
+      reduce(add, 0)
+    )(this.beneficiariesFormArray.value);
+  }
+
+  get totalBeneficiaries(): number {
+    return this.beneficiariesFormArray.value.length;
+  }
+
+  constructor(private formBuilder: FormBuilder) {}
+
+  addBeneficiary(): void {
+    this.beneficiariesFormArray.push(this.createBeneficiary());
+  }
+
+  formatSliderThumbLabel(value: number | null): string {
+    return `${value}%`;
+  }
+
+  getBeneficiaryAccountControl(i: number): FormControl | undefined {
+    return path(
+      ['controls', 'account'],
+      this.beneficiariesFormArray.controls[i]
+    );
+  }
+
+  removeBeneficiary(i: number): void {
+    this.beneficiariesFormArray.removeAt(i);
+  }
+
+  private createBeneficiary(): FormGroup {
+    return this.formBuilder.group({
+      account: ['', [Validators.required, Validators.pattern(/^[\w|-]+$/)]],
+      weight: [0, [Validators.required, Validators.min(0), Validators.max(100)]]
+    });
+  }
+}

--- a/src/app/editor/components/body-partial-form/body-partial-form.component.html
+++ b/src/app/editor/components/body-partial-form/body-partial-form.component.html
@@ -1,0 +1,6 @@
+<div [formGroup]="parentForm">
+  <mat-form-field class="body__field">
+    <textarea matInput formControlName="body" placeholder="Write your article" class="body__textarea"></textarea>
+    <mat-error *ngIf="bodyControl.hasError('required')" class="body__error body__error--required">{{ errorMessages.required }}</mat-error>
+  </mat-form-field>
+</div>

--- a/src/app/editor/components/body-partial-form/body-partial-form.component.scss
+++ b/src/app/editor/components/body-partial-form/body-partial-form.component.scss
@@ -1,0 +1,7 @@
+.body__field {
+  width: 100%;
+}
+
+.body__textarea {
+  min-height: 400px;
+}

--- a/src/app/editor/components/body-partial-form/body-partial-form.component.spec.ts
+++ b/src/app/editor/components/body-partial-form/body-partial-form.component.spec.ts
@@ -1,0 +1,114 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  ViewChild
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EditorMaterialModule } from './../../editor-material/editor-material.module';
+import { BodyPartialFormComponent } from './body-partial-form.component';
+
+@Component({
+  selector: `app-host-component`,
+  template: `<app-body-partial-form [parentForm]="parentForm"></app-body-partial-form>`
+})
+class TestHostComponent {
+  @ViewChild(BodyPartialFormComponent)
+  bodyPartialFormComponent: BodyPartialFormComponent;
+
+  parentForm: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      body: ['', Validators.required]
+    });
+  }
+}
+
+fdescribe('#EditorModule BodyPartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: BodyPartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, BodyPartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(BodyPartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.bodyPartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('#bodyControl should be pointing on `parentForm.controls.body`', () => {
+    expect(component.bodyControl).toBe(hostComponent.parentForm.controls.body);
+  });
+
+  it('(.body__error-required) should NOT be rendered when `bodyControl` is empty but not touched', () => {
+    let bodyRequiredElement: DebugElement;
+    component.bodyControl.setValue('');
+    component.bodyControl.markAsUntouched();
+    hostFixture.detectChanges();
+
+    bodyRequiredElement = hostFixture.debugElement.query(
+      By.css('.body__error--required')
+    );
+
+    expect(bodyRequiredElement).toEqual(null);
+  });
+
+  it('(.body__error-required) should be rendered and contain correct error message when `bodyControl` is empty and touched', () => {
+    let bodyRequiredElement: DebugElement;
+
+    component.bodyControl.setValue('');
+    component.bodyControl.markAsTouched();
+    hostFixture.detectChanges();
+
+    bodyRequiredElement = hostFixture.debugElement.query(
+      By.css('.body__error--required')
+    );
+
+    expect(bodyRequiredElement.nativeElement.innerText).toContain(
+      component.errorMessages.required
+    );
+  });
+
+  it('(.body__textarea) should make `bodyControl` valid when user types correct text into it', () => {
+    const bodyControl = component.bodyControl;
+    const bodyTextarea: HTMLTextAreaElement = hostFixture.debugElement.query(
+      By.css('.body__textarea')
+    ).nativeElement;
+
+    bodyTextarea.value = 'Test 123';
+    bodyTextarea.dispatchEvent(new Event('input'));
+
+    expect(bodyControl.valid).toBeTruthy();
+  });
+});

--- a/src/app/editor/components/body-partial-form/body-partial-form.component.ts
+++ b/src/app/editor/components/body-partial-form/body-partial-form.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-body-partial-form',
+  templateUrl: './body-partial-form.component.html',
+  styleUrls: ['./body-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BodyPartialFormComponent {
+  @Input() parentForm: FormGroup;
+
+  readonly errorMessages = {
+    required: 'Body cannot be empty!'
+  };
+
+  get bodyControl(): AbstractControl {
+    return this.parentForm.get('body');
+  }
+}

--- a/src/app/editor/components/community-partial-form/community-partial-form.component.html
+++ b/src/app/editor/components/community-partial-form/community-partial-form.component.html
@@ -1,0 +1,7 @@
+<div [formGroup]="parentForm">
+  <mat-form-field class="community__field">
+    <input matInput [errorStateMatcher]="onDirtyMatcher" formControlName="community" type="text" placeholder="Community" class="community__input">
+    <mat-error *ngIf="communityControl.hasError('required')" class="community__error community__error--required">{{ errorMessages.required }}</mat-error>
+    <mat-error *ngIf="communityControl.hasError('pattern')" class="community__error community__error--pattern">{{ errorMessages.pattern }}</mat-error>
+  </mat-form-field>
+</div>

--- a/src/app/editor/components/community-partial-form/community-partial-form.component.scss
+++ b/src/app/editor/components/community-partial-form/community-partial-form.component.scss
@@ -1,0 +1,3 @@
+.community__field {
+  width: 100%;
+}

--- a/src/app/editor/components/community-partial-form/community-partial-form.component.spec.ts
+++ b/src/app/editor/components/community-partial-form/community-partial-form.component.spec.ts
@@ -1,0 +1,133 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  ViewChild
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EditorMaterialModule } from '../../editor-material/editor-material.module';
+import { CommunityPartialFormComponent } from './community-partial-form.component';
+
+@Component({
+  selector: `app-host-component`,
+  template: `<app-community-partial-form [parentForm]="parentForm"></app-community-partial-form>`
+})
+class TestHostComponent {
+  @ViewChild(CommunityPartialFormComponent)
+  communityPartialFormComponent: CommunityPartialFormComponent;
+
+  parentForm: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      community: ['', Validators.required, Validators.pattern(/^[a-z]+$/)]
+    });
+  }
+}
+
+fdescribe('#EditorModule CommunityPartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: CommunityPartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, CommunityPartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(CommunityPartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.communityPartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#communityControl should be pointing on `parentForm.controls.community`', () => {
+    expect(component.communityControl).toBe(
+      component.parentForm.controls.community
+    );
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.community__error--required) should be rendered if `communityControl` has `required` error and is dirty + should contain correct message', () => {
+    let communityErrorRequiredElement: DebugElement;
+
+    component.communityControl.setErrors({ required: true });
+    component.communityControl.markAsDirty();
+    hostFixture.detectChanges();
+    communityErrorRequiredElement = hostFixture.debugElement.query(
+      By.css('.community__error--required')
+    );
+
+    expect(communityErrorRequiredElement.nativeElement).toBeDefined();
+    expect(communityErrorRequiredElement.nativeElement.innerText).toContain(
+      component.errorMessages.required
+    );
+  });
+
+  it('(.community__error--required) should NOT be rendered if `communityControl` does NOT have `required` error', () => {
+    let communityErrorRequiredElement: DebugElement;
+
+    component.communityControl.setErrors(null);
+    hostFixture.detectChanges();
+    communityErrorRequiredElement = hostFixture.debugElement.query(
+      By.css('.community__error--required')
+    );
+
+    expect(communityErrorRequiredElement).toEqual(null);
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.community__error--pattern) should be rendered if `communityControl` has `pattern` error and is dirty + should contain correct message', () => {
+    let communityErrorPatternElement: DebugElement;
+
+    component.communityControl.setErrors({ pattern: true });
+    component.communityControl.markAsDirty();
+    hostFixture.detectChanges();
+    communityErrorPatternElement = hostFixture.debugElement.query(
+      By.css('.community__error--pattern')
+    );
+
+    expect(communityErrorPatternElement.nativeElement).toBeDefined();
+    expect(communityErrorPatternElement.nativeElement.innerText).toContain(
+      component.errorMessages.pattern
+    );
+  });
+
+  it('(.community__error--pattern) should NOT be rendered if `communityControl` does NOT have `pattern` error', () => {
+    let communityErrorPatternElement: DebugElement;
+
+    component.communityControl.setErrors(null);
+    hostFixture.detectChanges();
+    communityErrorPatternElement = hostFixture.debugElement.query(
+      By.css('.community__error--pattern')
+    );
+
+    expect(communityErrorPatternElement).toEqual(null);
+  });
+});

--- a/src/app/editor/components/community-partial-form/community-partial-form.component.ts
+++ b/src/app/editor/components/community-partial-form/community-partial-form.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
+
+@Component({
+  selector: 'app-community-partial-form',
+  templateUrl: './community-partial-form.component.html',
+  styleUrls: ['./community-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CommunityPartialFormComponent {
+  @Input() parentForm: FormGroup;
+
+  onDirtyMatcher = new ShowOnDirtyErrorStateMatcher();
+
+  readonly errorMessages = {
+    required: 'Community cannot be empty!',
+    pattern: 'Community can only contain lower case letters!'
+  };
+
+  get communityControl(): AbstractControl {
+    return this.parentForm.get('community');
+  }
+}

--- a/src/app/editor/components/editor/config.spec.ts
+++ b/src/app/editor/components/editor/config.spec.ts
@@ -1,0 +1,59 @@
+import { createEditorConfig, initialConfig } from './config';
+
+fdescribe('#EditorModule EditorComponent config', () => {
+  fdescribe('createEditorConfig', () => {
+    it('should create config without provided argument', () => {
+      const config = createEditorConfig();
+
+      expect(config).toEqual(initialConfig);
+    });
+
+    it('should create correct config if only part of config properties were provided', () => {
+      const deep0Change = { whenChangesDebounceTime: 1000 };
+      const deep1Change = {
+        fields: {
+          body: {
+            value: 'test1',
+            disabled: true
+          }
+        }
+      };
+      const deep2Change = {
+        fields: {
+          body: {
+            value: 'test2'
+          }
+        }
+      };
+
+      const configWithDeep0Change = createEditorConfig(deep0Change);
+      const configWithDeep1Change = createEditorConfig(deep1Change);
+      const configWithDeep2Change = createEditorConfig(deep2Change);
+
+      expect(configWithDeep0Change).toEqual({
+        ...initialConfig,
+        whenChangesDebounceTime: 1000
+      });
+      expect(configWithDeep1Change).toEqual({
+        ...initialConfig,
+        fields: {
+          ...initialConfig.fields,
+          body: {
+            value: 'test1',
+            disabled: true
+          }
+        }
+      });
+      expect(configWithDeep2Change).toEqual({
+        ...initialConfig,
+        fields: {
+          ...initialConfig.fields,
+          body: {
+            ...initialConfig.fields.body,
+            value: 'test2'
+          }
+        }
+      });
+    });
+  });
+});

--- a/src/app/editor/components/editor/config.ts
+++ b/src/app/editor/components/editor/config.ts
@@ -1,0 +1,168 @@
+import { pipe, always, mergeDeepRight, ifElse, isNil, identity } from 'ramda';
+
+export interface Field<T> {
+  value: T;
+  disabled: boolean;
+}
+
+export interface TitleField extends Field<string> {}
+
+export interface BodyField extends Field<string> {}
+
+export interface CommunityField extends Field<string> {}
+
+export interface TagsField extends Field<string[]> {
+  disableRemovingFirstTag: boolean;
+}
+
+export interface ThumbnailUrlField extends Field<string> {}
+
+export interface AllowVotesField extends Field<boolean> {}
+
+export interface AllowCurationRewardsField extends Field<boolean> {}
+
+export interface PercentSteemDollarsField extends Field<number> {
+  min: number;
+  max: number;
+}
+
+export interface MaxAcceptedPayoutField extends Field<number> {
+  min: number;
+  max: number;
+}
+
+export interface JsonMetadataField extends Field<string> {}
+
+export interface BeneficiariesField
+  extends Field<
+      Array<{
+        account: string;
+        weight: number;
+      }>
+    > {
+  disableAdding: boolean;
+  disableRemoving: boolean;
+}
+
+export interface EditorFields {
+  title: TitleField;
+  body: BodyField;
+  community: CommunityField;
+  tags: TagsField;
+  thumbnailUrl: ThumbnailUrlField;
+  allowVotes: AllowVotesField;
+  allowCurationRewards: AllowCurationRewardsField;
+  percentSteemDollars: PercentSteemDollarsField;
+  maxAcceptedPayout: MaxAcceptedPayoutField;
+  jsonMetadata: JsonMetadataField;
+  beneficiaries: BeneficiariesField;
+}
+
+export interface EditorConfig {
+  /**
+   * Config of all fields available in the editor.
+   */
+  fields: EditorFields;
+
+  /**
+   * Time in milliseconds to wait after form changes, before triggering `whenChanges` event.
+   */
+  whenChangesDebounceTime: number;
+
+  /**
+   * Text to be displayed in a *Summary* section of the editor when forms are valid.
+   */
+  summaryStepValidText: string;
+
+  /**
+   * Text to be displayed in a *Summary* section of the editor when forms are invalid.
+   */
+  summaryStepInvalidText: string;
+
+  /**
+   * Text to be displayed on a button which submits `SteeditorPost`
+   */
+  submitButtonText: string;
+
+  /**
+   * Whether submit button should be disabled (it is also disabled when forms are invalid).
+   */
+  submitButtonDisabled: boolean;
+}
+
+export const initialConfig: EditorConfig = {
+  fields: {
+    title: {
+      value: '',
+      disabled: false
+    },
+    body: {
+      value: '',
+      disabled: false
+    },
+    community: {
+      value: '',
+      disabled: false
+    },
+    tags: {
+      value: [],
+      disabled: false,
+      disableRemovingFirstTag: false
+    },
+    thumbnailUrl: {
+      value: '',
+      disabled: false
+    },
+    allowVotes: {
+      value: true,
+      // TBC when a bug in api.steemit.com is removed
+      disabled: true
+    },
+    allowCurationRewards: {
+      value: true,
+      disabled: false
+    },
+    percentSteemDollars: {
+      value: 50,
+      disabled: false,
+      min: 0,
+      max: 50
+    },
+    maxAcceptedPayout: {
+      value: 1000000,
+      disabled: false,
+      min: 0,
+      max: 1000000
+    },
+    jsonMetadata: {
+      value: '',
+      disabled: false
+    },
+    beneficiaries: {
+      value: [],
+      disabled: false,
+      disableAdding: false,
+      disableRemoving: false
+    }
+  },
+  whenChangesDebounceTime: 3000,
+  summaryStepValidText:
+    'Everything is correct, the post is ready to be sent to the Steem blockchain!',
+  summaryStepInvalidText:
+    'The form is invalid, make sure you fill out all required fields and the data is correct!',
+  submitButtonText: 'Send',
+  submitButtonDisabled: false
+};
+
+type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
+
+/**
+ * Creates `EditorConfig` based on an object where all of `EditorConfig`'s properties are optional.
+ * It can be called without arguments too.
+ */
+export const createEditorConfig: (
+  config?: DeepPartial<EditorConfig>
+) => EditorConfig = pipe(
+  ifElse(isNil, always({}), identity),
+  mergeDeepRight(initialConfig)
+);

--- a/src/app/editor/components/editor/editor.component.html
+++ b/src/app/editor/components/editor/editor.component.html
@@ -1,0 +1,83 @@
+<mat-vertical-stepper #stepper="matVerticalStepper" class="editor">
+
+  <mat-step [stepControl]="contentForm">
+    <form [formGroup]="contentForm">
+      <ng-template matStepLabel>Fill out required fields</ng-template>
+
+      <app-title-partial-form [parentForm]="contentForm"></app-title-partial-form>
+
+      <div fxLayout fxLayout.lt-md="column" fxLayoutGap.gt-sm="2" fxLayoutAlign.gt-sm="space-between end" class="editor__multi-fields-container">
+
+        <div fxFlex="69" fxFlex.lt-md="100">
+          <app-tags-partial-form [parentForm]="contentForm" [disableRemovingFirstTag]="isRemovingFirstTagDisabled"></app-tags-partial-form>
+        </div>
+
+        <div fxFlex="29" fxFlex.lt-md="100">
+          <app-community-partial-form [parentForm]="contentForm"></app-community-partial-form>
+        </div>
+
+      </div>
+
+      <div fxLayout fxLayout.lt-md="column" fxLayoutGap.gt-sm="2" fxLayoutAlign.gt-sm="space-between start" class="editor__multi-fields-container">
+
+        <div fxFlex="29" fxFlex.lt-md="100" fxFlexOrder.lt-md="2">
+          <app-thumbnail-partial-form [parentForm]="contentForm"></app-thumbnail-partial-form>
+        </div>
+
+        <div fxFlex="69" fxFlex.lt-md="100" fxFlexOrder.lt-md="1">
+          <mat-card class="editor__card">
+            <mat-tab-group>
+              <mat-tab label="Edit">
+                <app-body-partial-form [parentForm]="contentForm"></app-body-partial-form>
+              </mat-tab>
+              <mat-tab label="Preview">
+                <app-post-preview [postBody]="(contentForm.valueChanges | async)?.body"></app-post-preview>
+              </mat-tab>
+            </mat-tab-group>
+          </mat-card>
+        </div>
+
+      </div>
+
+      <div class="editor__step-buttons">
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+
+  <mat-step [stepControl]="advancedOptionsForm" optional="true">
+    <form [formGroup]="advancedOptionsForm">
+      <ng-template matStepLabel>Change advanced options</ng-template>
+      <div fxLayout fxLayout.lt-lg="column" fxLayoutGap="2" fxLayoutAlign.gt-md="space-between start" class="advanced-options">
+        <div fxFlex="26" fxFlex.lt-lg="100" class="advanced-options__element">
+          <app-options-partial-form [parentForm]="advancedOptionsForm" [config]="config"></app-options-partial-form>
+        </div>
+
+        <div fxFlex="30" fxFlex.lt-lg="100" class="advanced-options__element">
+          <app-json-metadata-partial-form [parentForm]="advancedOptionsForm" [currentSteeditorPost]="currentSteeditorPost"></app-json-metadata-partial-form>
+        </div>
+
+        <div fxFlex="40" fxFlex.lt-lg="100" class="advanced-options__element">
+          <app-beneficiaries-partial-form [parentForm]="advancedOptionsForm"></app-beneficiaries-partial-form>
+        </div>
+      </div>
+      <div class="editor__step-buttons">
+        <button mat-button matStepperPrevious>Back</button>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Summary</ng-template>
+
+    <p *ngIf="contentForm.valid && advancedOptionsForm.valid" class="editor__summary-text--valid">{{config.summaryStepValidText}}</p>
+    <p *ngIf="contentForm.invalid || advancedOptionsForm.invalid" class="editor__summary-text--invalid">{{config.summaryStepInvalidText}}</p>
+
+    <div class="editor__step-buttons">
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button color="accent" [disabled]="contentForm.invalid || advancedOptionsForm.invalid || config.submitButtonDisabled"
+        (click)="onSubmit()" class="editor__submit-button">{{config.submitButtonText}}</button>
+    </div>
+  </mat-step>
+
+</mat-vertical-stepper>

--- a/src/app/editor/components/editor/editor.component.scss
+++ b/src/app/editor/components/editor/editor.component.scss
@@ -1,0 +1,19 @@
+.editor__step-buttons {
+  margin-top: 30px;
+}
+
+.editor__card {
+  margin-bottom: 20px;
+}
+
+.editor__multi-fields-container {
+  margin-bottom: 20px;
+}
+
+.advanced-options {
+  padding: 20px 0;
+}
+
+.advanced-options__element {
+  padding: 10px 0;
+}

--- a/src/app/editor/components/editor/editor.component.spec.ts
+++ b/src/app/editor/components/editor/editor.component.spec.ts
@@ -1,0 +1,190 @@
+import { ChangeDetectionStrategy, DebugElement } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MarkdownModule } from 'ngx-markdown';
+import { forEachObjIndexed } from 'ramda';
+import { first } from 'rxjs/operators';
+import { SteeditorPost } from '../../../../core';
+import { EditorModule } from '../../editor.module';
+import { createEditorConfig } from './config';
+import { EditorComponent } from './editor.component';
+
+fdescribe('#EditorModule EditorComponent', () => {
+  let component: EditorComponent;
+  let fixture: ComponentFixture<EditorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [EditorModule, BrowserAnimationsModule, MarkdownModule.forRoot()]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(EditorComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should raise the `whenChanges` event when a control in either `contentForm` or `advancedOptionsForm` is changed', done => {
+    // `whenChangedDebounceTime` is changed to let tests pass faster
+    component.config = createEditorConfig({ whenChangesDebounceTime: 1 });
+
+    component.whenChanges.pipe(first()).subscribe(value => {
+      expect(value).toBeDefined();
+      expect(value.body).toEqual('123');
+      expect(value.allowCurationRewards).toBeDefined();
+      done();
+    });
+    component.contentForm.controls.body.setValue('123');
+  });
+
+  it('#onSubmit() should raise the `whenSubmit` event with the forms value merged into one object', () => {
+    const formsValue: SteeditorPost = {
+      ...component.contentForm.getRawValue(),
+      ...component.advancedOptionsForm.getRawValue()
+    };
+    let emittedValue;
+    component.whenSubmit.subscribe(
+      steeditorPost => (emittedValue = steeditorPost)
+    );
+
+    component.onSubmit();
+
+    expect(emittedValue).toEqual(formsValue);
+  });
+
+  it('#contentForm should be invalid when default values are set (at start)', () => {
+    const contentFormValidity: boolean = component.contentForm.valid;
+
+    expect(contentFormValidity).toBeFalsy();
+  });
+
+  it('#advancedOptionsForm should be valid when default values are set (at start)', () => {
+    const advancedOptionsFormValidity: boolean =
+      component.advancedOptionsForm.valid;
+
+    expect(advancedOptionsFormValidity).toBeTruthy();
+  });
+
+  it('#currentSteeditorPost should be equal to a current merged value of both forms', () => {
+    const expectedValue = {
+      ...component.contentForm.getRawValue(),
+      ...component.advancedOptionsForm.getRawValue()
+    };
+    const actualValue = component.currentSteeditorPost;
+
+    expect(actualValue).toEqual(expectedValue);
+  });
+
+  it('(.editor__submit-button) should be disabled when forms default values are set (at start)', () => {
+    const submitButton = fixture.debugElement.query(
+      By.css('.editor__submit-button')
+    );
+    const submitButtonDisabled = submitButton.nativeElement.disabled;
+
+    expect(submitButtonDisabled).toBeTruthy();
+  });
+
+  it('(.editor__submit-button) should be disabled when config prop `submitButtonDisabled` is truthy', () => {
+    let submitButton: HTMLButtonElement;
+
+    component.config = createEditorConfig({ submitButtonDisabled: true });
+    fixture.detectChanges();
+    submitButton = fixture.debugElement.query(By.css('.editor__submit-button'))
+      .nativeElement;
+
+    expect(submitButton.disabled).toBeTruthy();
+  });
+
+  it('(.editor__submit-button) should NOT be disabled when forms are valid and config prop `submitButtonDisabled` is falsy', () => {
+    let submitButton: HTMLButtonElement;
+
+    forEachObjIndexed(
+      control => control.setErrors(null),
+      component.contentForm.controls
+    );
+    component.config = createEditorConfig({ submitButtonDisabled: false });
+    fixture.detectChanges();
+    submitButton = fixture.debugElement.query(By.css('.editor__submit-button'))
+      .nativeElement;
+
+    expect(submitButton.disabled).toBeFalsy();
+  });
+
+  it('(.editor__summary-text--valid) should be rendered and display correct message if forms are valid', () => {
+    let summaryTextElement: DebugElement;
+
+    forEachObjIndexed(
+      control => control.setErrors(null),
+      component.contentForm.controls
+    );
+    fixture.detectChanges();
+    summaryTextElement = fixture.debugElement.query(
+      By.css('.editor__summary-text--valid')
+    );
+
+    expect(summaryTextElement.nativeElement).toBeDefined();
+    expect(summaryTextElement.nativeElement.innerHTML).toContain(
+      component.config.summaryStepValidText
+    );
+  });
+
+  it('(.editor__summary-text--valid) should NOT be rendered if forms are invalid', () => {
+    let summaryTextElement: DebugElement;
+
+    forEachObjIndexed(
+      control => control.setErrors({ testError: true }),
+      component.contentForm.controls
+    );
+    fixture.detectChanges();
+    summaryTextElement = fixture.debugElement.query(
+      By.css('.editor__summary-text--valid')
+    );
+
+    expect(summaryTextElement).toEqual(null);
+  });
+
+  it('(.editor__summary-text--invalid) should be rendered and display correct message if forms are invalid', () => {
+    let summaryTextElement: DebugElement;
+
+    forEachObjIndexed(
+      control => control.setErrors({ testError: true }),
+      component.contentForm.controls
+    );
+    fixture.detectChanges();
+    summaryTextElement = fixture.debugElement.query(
+      By.css('.editor__summary-text--invalid')
+    );
+
+    expect(summaryTextElement.nativeElement).toBeDefined();
+    expect(summaryTextElement.nativeElement.innerHTML).toContain(
+      component.config.summaryStepInvalidText
+    );
+  });
+
+  it('(.editor__summary-text--invalid) should NOT be rendered if forms are valid', () => {
+    let summaryTextElement: DebugElement;
+
+    forEachObjIndexed(
+      control => control.setErrors(null),
+      component.contentForm.controls
+    );
+    fixture.detectChanges();
+    summaryTextElement = fixture.debugElement.query(
+      By.css('.editor__summary-text--invalid')
+    );
+
+    expect(summaryTextElement).toEqual(null);
+  });
+});

--- a/src/app/editor/components/editor/editor.component.ts
+++ b/src/app/editor/components/editor/editor.component.ts
@@ -1,0 +1,217 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output
+} from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { map, mergeAll, prop } from 'ramda';
+import { merge, Subscription, timer } from 'rxjs';
+import { debounce } from 'rxjs/operators';
+import { SteeditorPost } from '../../../../core';
+import { tagsCustomValidators } from '../../validators/tags.validators';
+import { beneficiariesCustomValidators } from './../../validators/beneficiaries.validators';
+import { jsonMetadataCustomValidators } from './../../validators/json-metadata.validators';
+import {
+  AllowCurationRewardsField,
+  BeneficiariesField,
+  BodyField,
+  CommunityField,
+  EditorConfig,
+  EditorFields,
+  initialConfig,
+  JsonMetadataField,
+  MaxAcceptedPayoutField,
+  PercentSteemDollarsField,
+  TagsField,
+  ThumbnailUrlField,
+  TitleField
+} from './config';
+
+@Component({
+  selector: 'app-editor',
+  templateUrl: './editor.component.html',
+  styleUrls: ['./editor.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class EditorComponent implements OnInit, OnDestroy {
+  @Input() config: EditorConfig = initialConfig;
+
+  @Output() whenChanges = new EventEmitter<SteeditorPost>();
+  @Output() whenSubmit = new EventEmitter<SteeditorPost>();
+
+  contentForm: FormGroup;
+  advancedOptionsForm: FormGroup;
+
+  private mergedChangesSubscribtion: Subscription;
+
+  get currentSteeditorPost(): SteeditorPost {
+    return mergeAll([
+      this.contentForm.getRawValue(),
+      this.advancedOptionsForm.getRawValue()
+    ]);
+  }
+
+  get isRemovingFirstTagDisabled(): boolean {
+    return this.getConfigField<TagsField>('tags').disableRemovingFirstTag;
+  }
+
+  constructor(private formBuilder: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.buildForms();
+
+    this.mergedChangesSubscribtion = merge(
+      this.contentForm.valueChanges,
+      this.advancedOptionsForm.valueChanges
+    )
+      .pipe(debounce(() => timer(this.config.whenChangesDebounceTime)))
+      .subscribe(() => {
+        this.whenChanges.emit(this.currentSteeditorPost);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.mergedChangesSubscribtion.unsubscribe();
+  }
+
+  onSubmit(): void {
+    this.whenSubmit.emit(mergeAll([this.currentSteeditorPost]));
+  }
+
+  private buildForms(): void {
+    this.buildContentForm();
+    this.buildAdvancedOptionsForm();
+  }
+
+  private buildContentForm(): void {
+    const titleFieldConfig = this.getConfigField<TitleField>('title');
+    const bodyFieldConfig = this.getConfigField<BodyField>('body');
+    const communityFieldConfig = this.getConfigField<CommunityField>(
+      'community'
+    );
+    const tagsFieldConfig = this.getConfigField<TagsField>('tags');
+    const thumbnailUrlFieldConfig = this.getConfigField<ThumbnailUrlField>(
+      'thumbnailUrl'
+    );
+
+    this.contentForm = this.formBuilder.group({
+      title: [
+        { value: titleFieldConfig.value, disabled: titleFieldConfig.disabled },
+        Validators.required
+      ],
+      body: [
+        { value: bodyFieldConfig.value, disabled: bodyFieldConfig.disabled },
+        Validators.required
+      ],
+      community: [
+        {
+          value: communityFieldConfig.value,
+          disabled: communityFieldConfig.disabled
+        },
+        [Validators.required, Validators.pattern(/^[a-z]+$/)]
+      ],
+      tags: [
+        { value: tagsFieldConfig.value, disabled: tagsFieldConfig.disabled },
+        [Validators.required, ...tagsCustomValidators]
+      ],
+      thumbnailUrl: [
+        {
+          value: thumbnailUrlFieldConfig.value,
+          disabled: thumbnailUrlFieldConfig.disabled
+        },
+        Validators.pattern(
+          // tslint:disable-next-line:max-line-length
+          /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})/
+        )
+      ]
+    });
+  }
+
+  private buildAdvancedOptionsForm(): void {
+    const beneficiariesFieldConfig = this.getConfigField<BeneficiariesField>(
+      'beneficiaries'
+    );
+    const allowVotesFieldConfig = this.getConfigField<
+      AllowCurationRewardsField
+    >('allowVotes');
+    const allowCurationRewardsFieldConfig = this.getConfigField<
+      AllowCurationRewardsField
+    >('allowCurationRewards');
+    const percentSteemDollarsFieldConfig = this.getConfigField<
+      PercentSteemDollarsField
+    >('percentSteemDollars');
+    const maxAcceptedPayoutFieldConfig = this.getConfigField<
+      MaxAcceptedPayoutField
+    >('maxAcceptedPayout');
+    const jsonMetadataFieldConfig = this.getConfigField<JsonMetadataField>(
+      'jsonMetadata'
+    );
+
+    this.advancedOptionsForm = this.formBuilder.group({
+      beneficiaries: this.formBuilder.array(
+        map(
+          beneficiary =>
+            this.formBuilder.group({
+              account: [
+                beneficiary.account,
+                [Validators.required, Validators.pattern(/^[\w|-]+$/)]
+              ],
+              weight: [
+                beneficiary.weight,
+                [Validators.required, Validators.min(0), Validators.max(100)]
+              ]
+            }),
+          beneficiariesFieldConfig.value
+        ),
+        beneficiariesCustomValidators
+      ),
+      allowVotes: [
+        {
+          value: allowVotesFieldConfig.value,
+          disabled: allowVotesFieldConfig.disabled
+        }
+      ],
+      allowCurationRewards: [
+        {
+          value: allowCurationRewardsFieldConfig.value,
+          disabled: allowCurationRewardsFieldConfig.disabled
+        }
+      ],
+      percentSteemDollars: [
+        {
+          value: percentSteemDollarsFieldConfig.value,
+          disabled: percentSteemDollarsFieldConfig.disabled
+        },
+        [
+          Validators.min(percentSteemDollarsFieldConfig.min),
+          Validators.max(percentSteemDollarsFieldConfig.max)
+        ]
+      ],
+      maxAcceptedPayout: [
+        {
+          value: maxAcceptedPayoutFieldConfig.value,
+          disabled: maxAcceptedPayoutFieldConfig.disabled
+        },
+        [
+          Validators.min(maxAcceptedPayoutFieldConfig.min),
+          Validators.max(maxAcceptedPayoutFieldConfig.max)
+        ]
+      ],
+      jsonMetadata: [
+        {
+          value: jsonMetadataFieldConfig.value,
+          disabled: jsonMetadataFieldConfig.disabled
+        },
+        jsonMetadataCustomValidators
+      ]
+    });
+  }
+
+  private getConfigField<T>(fieldName: keyof EditorFields): T {
+    return prop(fieldName, this.config.fields);
+  }
+}

--- a/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.html
+++ b/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.html
@@ -1,0 +1,33 @@
+<div [formGroup]="parentForm">
+  <mat-card>
+    <h3>Metadata
+      <sup matTooltip="Metadata is a set of properties describing a post. Don't change it unless you know what you are doing!"
+        matTooltipPosition="right">
+        <mat-icon color="primary">info</mat-icon>
+      </sup>
+    </h3>
+
+    <mat-divider></mat-divider>
+
+    <div class="custom-metadata">
+      <mat-form-field class="custom-metadata__field">
+        <textarea matInput [errorStateMatcher]="onDirtyMatcher" formControlName="jsonMetadata" placeholder="Enter your custom JSON metadata"
+          class="custom-metadata__textarea"></textarea>
+        <mat-error *ngIf="jsonMetadataControl.hasError('invalidJson')" class="custom-metadata__error custom-metadata__error--invalid-json">{{ errorMessages.invalidJson }}</mat-error>
+      </mat-form-field>
+    </div>
+
+    <mat-accordion>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            Current JSON metadata
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+        <div class="current-metadata">
+          <pre>{{currentMetadata | json}}</pre>
+        </div>
+      </mat-expansion-panel>
+    </mat-accordion>
+  </mat-card>
+</div>

--- a/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.scss
+++ b/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.scss
@@ -1,0 +1,16 @@
+.custom-metadata {
+  padding: 10px;
+}
+
+.custom-metadata__field {
+  width: 100%;
+}
+
+.custom-metadata__textarea {
+  min-height: 60px;
+}
+
+.current-metadata {
+  max-width: 100%;
+  overflow-x: scroll;
+}

--- a/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.spec.ts
+++ b/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.spec.ts
@@ -1,0 +1,143 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  ViewChild
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EditorMaterialModule } from '../../editor-material/editor-material.module';
+import { jsonMetadataCustomValidators } from '../../validators/json-metadata.validators';
+import { SteeditorPost } from './../../../../core/SteeditorPost';
+import { JsonMetadataPartialFormComponent } from './json-metadata-partial-form.component';
+
+@Component({
+  selector: `app-host-component`,
+  template: `
+  <app-json-metadata-partial-form [parentForm]="parentForm" [currentSteeditorPost]="currentSteeditorPost">
+  </app-json-metadata-partial-form>
+  `
+})
+class TestHostComponent {
+  @ViewChild(JsonMetadataPartialFormComponent)
+  jsonMetadataPartialFormComponent: JsonMetadataPartialFormComponent;
+
+  parentForm: FormGroup;
+  currentSteeditorPost: SteeditorPost;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      jsonMetadata: ['', jsonMetadataCustomValidators]
+    });
+
+    this.currentSteeditorPost = {
+      title: '',
+      body: '',
+      tags: [],
+      community: '',
+      thumbnailUrl: '',
+      beneficiaries: [],
+      allowVotes: true,
+      allowCurationRewards: true,
+      percentSteemDollars: 50,
+      maxAcceptedPayout: 0,
+      jsonMetadata: ''
+    };
+  }
+}
+
+fdescribe('#EditorModule JsonMetadataPartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: JsonMetadataPartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, JsonMetadataPartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(JsonMetadataPartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.jsonMetadataPartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#jsonMetadataControl should be pointing on `parentForm.controls.jsonMetadata`', () => {
+    expect(component.jsonMetadataControl).toBe(
+      component.parentForm.controls.jsonMetadata
+    );
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('#currentMetadata should be an object created based on `(core)createJsonMetadata` + all props of `currentSteeditorPost` if `jsonMetadataControl` is valid', () => {
+    component.jsonMetadataControl.setErrors(null);
+    component.currentSteeditorPost = {
+      ...component.currentSteeditorPost,
+      jsonMetadata: '{"testProp":"test"}'
+    };
+
+    expect(component.currentMetadata.testProp).toEqual('test');
+    expect(component.currentMetadata.app).toBeDefined();
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('#currentMetadata should be an object created based on `(core)createJsonMetadata` + all props of `currentSteeditorPost` except `jsonMetadata`, if `jsonMetadataControl` is invalid', () => {
+    component.jsonMetadataControl.setErrors({ testError: true });
+    component.currentSteeditorPost = {
+      ...component.currentSteeditorPost,
+      jsonMetadata: '{"testProp":"test"}'
+    };
+
+    expect(component.currentMetadata.testProp).toBeUndefined();
+    expect(component.currentMetadata.app).toBeDefined();
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.custom-metadata__error--invalid-json) should be rendered if `jsonMetadataControl` has `invalidJson` error and is dirty + should contain correct message', () => {
+    let errorElement: DebugElement;
+
+    component.jsonMetadataControl.setErrors({ invalidJson: true });
+    component.jsonMetadataControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.custom-metadata__error--invalid-json')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.invalidJson
+    );
+  });
+
+  it('(.custom-metadata__error--invalid-json) should NOT be rendered if `jsonMetadataControl` does NOT have `invalidJson` error', () => {
+    let errorElement: DebugElement;
+
+    component.jsonMetadataControl.setErrors(null);
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.custom-metadata__error--invalid-json')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+});

--- a/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.ts
+++ b/src/app/editor/components/json-metadata-partial-form/json-metadata-partial-form.component.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
+import { assoc, clone, pipe, unary } from 'ramda';
+import { createJsonMetadata } from '../../../../core/steemize/withJsonMetadata';
+import { SteeditorPost } from './../../../../core/SteeditorPost';
+
+@Component({
+  selector: 'app-json-metadata-partial-form',
+  templateUrl: './json-metadata-partial-form.component.html',
+  styleUrls: ['./json-metadata-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class JsonMetadataPartialFormComponent {
+  @Input() parentForm: FormGroup;
+  @Input() currentSteeditorPost: SteeditorPost;
+
+  onDirtyMatcher = new ShowOnDirtyErrorStateMatcher();
+
+  readonly errorMessages = {
+    invalidJson: 'Please enter a valid JSON!'
+  };
+
+  get currentMetadata(): { [K: string]: any } {
+    return pipe(
+      () =>
+        this.jsonMetadataControl.valid
+          ? clone(this.currentSteeditorPost)
+          : assoc('jsonMetadata', '', this.currentSteeditorPost),
+      createJsonMetadata,
+      unary(JSON.parse)
+    )();
+  }
+
+  get jsonMetadataControl(): AbstractControl {
+    return this.parentForm.get('jsonMetadata');
+  }
+}

--- a/src/app/editor/components/options-partial-form/options-partial-form.component.html
+++ b/src/app/editor/components/options-partial-form/options-partial-form.component.html
@@ -1,0 +1,49 @@
+<div [formGroup]="parentForm">
+  <mat-card>
+    <div fxLayout="column" fxLayoutGap="5" class="options">
+      <div fxFlex>
+        <p class="mat-body">Allow votes:
+          <sup matTooltip="Should voting on your post be possible?" matTooltipPosition="right">
+            <mat-icon color="primary">info</mat-icon>
+          </sup>
+        </p>
+        <mat-slide-toggle formControlName="allowVotes"></mat-slide-toggle>
+      </div>
+
+      <div fxFlex>
+        <p class="mat-body">Allow curation rewards:
+          <sup matTooltip="Should voters receive curation rewards? Turned off, curation rewards would return to the reward pool, you wouldn't earn more."
+            matTooltipPosition="right">
+            <mat-icon color="primary">info</mat-icon>
+          </sup>
+        </p>
+        <mat-slide-toggle formControlName="allowCurationRewards"></mat-slide-toggle>
+      </div>
+
+      <div fxFlex>
+        <p class="mat-body">Maximal accepted payout:
+          <sup matTooltip="Maximum payout in Steem Dollars that a post can receive." matTooltipPosition="right">
+            <mat-icon color="primary">info</mat-icon>
+          </sup>
+        </p>
+        <mat-form-field>
+          <input matInput type="number" [errorStateMatcher]="onDirtyMatcher" [min]="maxAcceptedPayoutConfig.min" [max]="maxAcceptedPayoutConfig.max"
+            formControlName="maxAcceptedPayout">
+          <span matSuffix>SBD</span>
+          <mat-error *ngIf="maxAcceptedPayoutControl.hasError('min')" class="max-accepted-payout__error max-accepted-payout__error--min">{{errorMessagesMaxAcceptedPayout.min}}</mat-error>
+          <mat-error *ngIf="maxAcceptedPayoutControl.hasError('max')" class="max-accepted-payout__error max-accepted-payout__error--max">{{errorMessagesMaxAcceptedPayout.max}}</mat-error>
+        </mat-form-field>
+      </div>
+
+      <div fxFlex>
+        <p class="mat-body">Percent Steem Dollars:
+          <sup matTooltip="Percent of Steem Dollars in the payout, remaining part will be received as Steem Power." matTooltipPosition="right">
+            <mat-icon color="primary">info</mat-icon>
+          </sup>
+        </p>
+        <mat-slider [min]="percentSteemDollarsConfig.min" [max]="percentSteemDollarsConfig.max" step="1" thumbLabel [displayWith]="formatSliderThumbLabel"
+          formControlName="percentSteemDollars" class="options__slider"></mat-slider>
+      </div>
+    </div>
+  </mat-card>
+</div>

--- a/src/app/editor/components/options-partial-form/options-partial-form.component.scss
+++ b/src/app/editor/components/options-partial-form/options-partial-form.component.scss
@@ -1,0 +1,3 @@
+.options__slider {
+  width: 70%;
+}

--- a/src/app/editor/components/options-partial-form/options-partial-form.component.spec.ts
+++ b/src/app/editor/components/options-partial-form/options-partial-form.component.spec.ts
@@ -1,0 +1,152 @@
+import { EditorConfig, createEditorConfig } from './../editor/config';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewChild,
+  DebugElement
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EditorMaterialModule } from '../../editor-material/editor-material.module';
+import { OptionsPartialFormComponent } from './options-partial-form.component';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  selector: `app-host-component`,
+  template: `
+  <app-options-partial-form [parentForm]="parentForm" [config]="config">
+  </app-options-partial-form>
+  `
+})
+class TestHostComponent {
+  @ViewChild(OptionsPartialFormComponent)
+  optionsPartialFormComponent: OptionsPartialFormComponent;
+
+  parentForm: FormGroup;
+  config: EditorConfig;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      allowVotes: [true],
+      allowCurationRewards: [true],
+      percentSteemDollars: [50, [Validators.min(0), Validators.max(50)]],
+      maxAcceptedPayout: [100000, [Validators.min(0), Validators.max(100000)]]
+    });
+
+    this.config = createEditorConfig();
+  }
+}
+
+fdescribe('#EditorModule OptionsPartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: OptionsPartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, OptionsPartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(OptionsPartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.optionsPartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#maxAcceptedPayoutControl should be pointing on `parentForm.controls.maxAcceptedPayout`', () => {
+    expect(component.maxAcceptedPayoutControl).toBe(
+      component.parentForm.controls.maxAcceptedPayout
+    );
+  });
+
+  it('#formatSliderThumbLabel should add a "%" to the value', () => {
+    const value = 10;
+    let formattedValue: string;
+
+    formattedValue = component.formatSliderThumbLabel(value);
+
+    expect(formattedValue).toBe('10%');
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.max-accepted-payout__error--min) should be rendered and contain a correct message if `maxAcceptedPayoutControl` has `min` error and is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.maxAcceptedPayoutControl.setErrors({ min: true });
+    component.maxAcceptedPayoutControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.max-accepted-payout__error--min')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessagesMaxAcceptedPayout.min
+    );
+  });
+
+  it('(.max-accepted-payout__error--min) should NOT be rendered  if `maxAcceptedPayoutControl` does NOT have `min` error', () => {
+    let errorElement: DebugElement;
+
+    component.maxAcceptedPayoutControl.setErrors(null);
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.max-accepted-payout__error--min')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.max-accepted-payout__error--max) should be rendered and contain a correct message if `maxAcceptedPayoutControl` has `max` error and is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.maxAcceptedPayoutControl.setErrors({ max: true });
+    component.maxAcceptedPayoutControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.max-accepted-payout__error--max')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessagesMaxAcceptedPayout.max
+    );
+  });
+
+  it('(.max-accepted-payout__error--max) should NOT be rendered  if `maxAcceptedPayoutControl` does NOT have `max` error', () => {
+    let errorElement: DebugElement;
+
+    component.maxAcceptedPayoutControl.setErrors(null);
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.max-accepted-payout__error--max')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+});

--- a/src/app/editor/components/options-partial-form/options-partial-form.component.ts
+++ b/src/app/editor/components/options-partial-form/options-partial-form.component.ts
@@ -1,0 +1,62 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit
+} from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
+import { path } from 'ramda';
+import {
+  EditorConfig,
+  MaxAcceptedPayoutField,
+  PercentSteemDollarsField
+} from './../editor/config';
+
+@Component({
+  selector: 'app-options-partial-form',
+  templateUrl: './options-partial-form.component.html',
+  styleUrls: ['./options-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class OptionsPartialFormComponent implements OnInit {
+  @Input() parentForm: FormGroup;
+  @Input() config: EditorConfig;
+
+  errorMessagesMaxAcceptedPayout: { min: string; max: string } = {
+    min: '',
+    max: ''
+  };
+  onDirtyMatcher = new ShowOnDirtyErrorStateMatcher();
+
+  get percentSteemDollarsConfig(): PercentSteemDollarsField {
+    return this.getFieldConfig<PercentSteemDollarsField>('percentSteemDollars');
+  }
+
+  get maxAcceptedPayoutConfig(): MaxAcceptedPayoutField {
+    return this.getFieldConfig<MaxAcceptedPayoutField>('maxAcceptedPayout');
+  }
+
+  get maxAcceptedPayoutControl(): AbstractControl {
+    return this.parentForm.get('maxAcceptedPayout');
+  }
+
+  ngOnInit() {
+    this.errorMessagesMaxAcceptedPayout = {
+      min: `Maximal accepted payout cannot be lower than ${
+        this.maxAcceptedPayoutConfig.min
+      }!`,
+      max: `Maximal accepted payout cannot be higher than ${
+        this.maxAcceptedPayoutConfig.max
+      }!`
+    };
+  }
+
+  formatSliderThumbLabel(value: number | null): string {
+    return `${value}%`;
+  }
+
+  private getFieldConfig<T>(fieldName: string): T {
+    return path(['fields', fieldName], this.config);
+  }
+}

--- a/src/app/editor/components/post-preview/post-preview.component.html
+++ b/src/app/editor/components/post-preview/post-preview.component.html
@@ -1,0 +1,1 @@
+<markdown [data]="postBody"></markdown>

--- a/src/app/editor/components/post-preview/post-preview.component.scss
+++ b/src/app/editor/components/post-preview/post-preview.component.scss
@@ -1,0 +1,3 @@
+.post-preview {
+  width: 100%;
+}

--- a/src/app/editor/components/post-preview/post-preview.component.spec.ts
+++ b/src/app/editor/components/post-preview/post-preview.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PostPreviewComponent } from './post-preview.component';
+
+// this component is gonna be changed much, don't write tests for it now
+describe('PostPreviewComponent', () => {
+  let component: PostPreviewComponent;
+  let fixture: ComponentFixture<PostPreviewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [PostPreviewComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PostPreviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/editor/components/post-preview/post-preview.component.ts
+++ b/src/app/editor/components/post-preview/post-preview.component.ts
@@ -1,0 +1,27 @@
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input
+} from '@angular/core';
+import { MarkdownService } from 'ngx-markdown';
+import { pipe, replace } from 'ramda';
+
+@Component({
+  selector: 'app-post-preview',
+  templateUrl: './post-preview.component.html',
+  styleUrls: ['./post-preview.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PostPreviewComponent implements OnInit {
+  @Input() postBody: string;
+
+  constructor(private markdownService: MarkdownService) {}
+
+  ngOnInit() {
+    this.markdownService.renderer.image = pipe(
+      this.markdownService.renderer.image,
+      replace(/src=/, 'style="max-width: 100%;" src=')
+    );
+  }
+}

--- a/src/app/editor/components/tags-partial-form/tags-partial-form.component.html
+++ b/src/app/editor/components/tags-partial-form/tags-partial-form.component.html
@@ -1,0 +1,18 @@
+<div [formGroup]="parentForm">
+  <mat-form-field class="tags__field">
+    <mat-chip-list #tagsList class="tags">
+      <mat-chip *ngFor="let tag of tagsControl.value; let i = index;" [color]="isValidTag(tag) ? 'primary' : 'warn'" selected [selectable]="false"
+        [removable]="isTagRemovable(i)" (removed)="removeTag(tag)" class="tag">
+        {{tag}}
+        <mat-icon *ngIf="isTagRemovable(i)" matChipRemove class="tag__remove">cancel</mat-icon>
+      </mat-chip>
+      <input matInput placeholder="Tags" [matChipInputFor]="tagsList" [matChipInputSeparatorKeyCodes]="separatorKeysCodes" [matChipInputAddOnBlur]="true"
+        (matChipInputTokenEnd)="addTag($event)" class="tags__input">
+    </mat-chip-list>
+  </mat-form-field>
+  <mat-error *ngIf="tagsControl.hasError('required') && tagsControl.dirty" class="tags__error tags__error--required">{{ errorMessages.required }}</mat-error>
+  <mat-error *ngIf="tagsControl.hasError('hash') && tagsControl.dirty" class="tags__error tags__error--hash">{{ errorMessages.hash }}</mat-error>
+  <mat-error *ngIf="tagsControl.hasError('whitespace') && tagsControl.dirty" class="tags__error tags__error--whitespace">{{ errorMessages.whitespace }}</mat-error>
+  <mat-error *ngIf="tagsControl.hasError('capitalLetters') && tagsControl.dirty" class="tags__error tags__error--capital-letters">{{ errorMessages.capitalLetters }}</mat-error>
+  <mat-error *ngIf="tagsControl.hasError('notUnique') && tagsControl.dirty" class="tags__error tags__error--not-unique">{{ errorMessages.notUnique }}</mat-error>
+</div>

--- a/src/app/editor/components/tags-partial-form/tags-partial-form.component.scss
+++ b/src/app/editor/components/tags-partial-form/tags-partial-form.component.scss
@@ -1,0 +1,3 @@
+.tags__field {
+  width: 100%;
+}

--- a/src/app/editor/components/tags-partial-form/tags-partial-form.component.spec.ts
+++ b/src/app/editor/components/tags-partial-form/tags-partial-form.component.spec.ts
@@ -1,0 +1,369 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  ViewChild
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EditorMaterialModule } from '../../editor-material/editor-material.module';
+import { tagsCustomValidators } from '../../validators/tags.validators';
+import { TagsPartialFormComponent } from './tags-partial-form.component';
+
+@Component({
+  selector: `app-host-component`,
+  template: `<app-tags-partial-form [parentForm]="parentForm"></app-tags-partial-form>`
+})
+class TestHostComponent {
+  @ViewChild(TagsPartialFormComponent)
+  tagsPartialFormComponent: TagsPartialFormComponent;
+
+  parentForm: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      tags: [[], [Validators.required, ...tagsCustomValidators]]
+    });
+  }
+}
+
+fdescribe('#EditorModule TagsPartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: TagsPartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, TagsPartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(TagsPartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.tagsPartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#tagsControl should be pointing on `parentForm.controls.tags`', () => {
+    expect(component.tagsControl).toBe(component.parentForm.controls.tags);
+  });
+
+  it('#removeTag should remove given tag and mark the `tagsControl` as dirty', () => {
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3']);
+    component.removeTag('tag2');
+
+    expect(component.tagsControl.value).toEqual(['tag1', 'tag3']);
+    expect(component.tagsControl.dirty).toBeTruthy();
+  });
+
+  it('#isTagRemovable should return true if tag is not first', () => {
+    expect(component.isTagRemovable(1)).toBeTruthy();
+    expect(component.isTagRemovable(2)).toBeTruthy();
+    expect(component.isTagRemovable(54)).toBeTruthy();
+
+    component.disableRemovingFirstTag = true;
+
+    expect(component.isTagRemovable(1)).toBeTruthy();
+    expect(component.isTagRemovable(2)).toBeTruthy();
+    expect(component.isTagRemovable(54)).toBeTruthy();
+  });
+
+  it('#isTagRemovable should return true if tag is first but `disableRemovingFirstTag` is falsy', () => {
+    component.disableRemovingFirstTag = false;
+
+    expect(component.isTagRemovable(0)).toBeTruthy();
+  });
+
+  it('#isTagRemovable should return false if tag is first and `disableRemovingFirstTag` is truthy', () => {
+    component.disableRemovingFirstTag = true;
+
+    expect(component.isTagRemovable(0)).toBeFalsy();
+  });
+
+  it('#isValidTag should return true if this tag has only valid chars and it is only once in `tagsControl.value``', () => {
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3']);
+
+    expect(component.isValidTag('tag3')).toBeTruthy();
+  });
+
+  it('#isValidTag should return false if this tag is at least twice in `tagsControl.value`', () => {
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3', 'tag2']);
+
+    expect(component.isValidTag('tag2')).toBeFalsy();
+
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3', 'tag2', 'tag2']);
+
+    expect(component.isValidTag('tag2')).toBeFalsy();
+  });
+
+  it('#isValidTag should return false if this tag has invalid chars`', () => {
+    component.tagsControl.setValue(['tag1', 'tag2', '#tag3']);
+
+    expect(component.isValidTag('#tag3')).toBeFalsy();
+  });
+
+  it('(.tag) should be rendered as many times as there are items in `tagsControl.value` and the values should be correct', () => {
+    let tagElements: DebugElement[];
+
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3']);
+    hostFixture.detectChanges();
+    tagElements = hostFixture.debugElement.queryAll(By.css('.tag'));
+
+    expect(tagElements.length).toEqual(3);
+    expect(tagElements[0].nativeElement.innerText).toContain('tag1');
+    expect(tagElements[1].nativeElement.innerText).toContain('tag2');
+    expect(tagElements[2].nativeElement.innerText).toContain('tag3');
+  });
+
+  it('(.tag) should have primary color if is valid', () => {
+    let tagElements: DebugElement[];
+
+    component.tagsControl.setValue(['tag1', 'tag2']);
+    hostFixture.detectChanges();
+    tagElements = hostFixture.debugElement.queryAll(By.css('.tag'));
+
+    expect(tagElements[0].nativeElement.outerHTML).toContain(
+      'ng-reflect-color="primary"'
+    );
+    expect(tagElements[1].nativeElement.outerHTML).toContain(
+      'ng-reflect-color="primary"'
+    );
+  });
+
+  it('(.tag) should have warn color if is invalid', () => {
+    let tagElements: DebugElement[];
+
+    component.tagsControl.setValue(['#tag1', 'tAg2', 'tag3']);
+    hostFixture.detectChanges();
+    tagElements = hostFixture.debugElement.queryAll(By.css('.tag'));
+
+    expect(tagElements[0].nativeElement.outerHTML).toContain(
+      'ng-reflect-color="warn"'
+    );
+    expect(tagElements[1].nativeElement.outerHTML).toContain(
+      'ng-reflect-color="warn"'
+    );
+
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3', 'tag2']);
+    hostFixture.detectChanges();
+    tagElements = hostFixture.debugElement.queryAll(By.css('.tag'));
+
+    expect(tagElements[1].nativeElement.outerHTML).toContain(
+      'ng-reflect-color="warn"'
+    );
+    expect(tagElements[3].nativeElement.outerHTML).toContain(
+      'ng-reflect-color="warn"'
+    );
+  });
+
+  it('(.tag) should be removable if is not first', () => {
+    let tagElements: DebugElement[];
+
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3']);
+    hostFixture.detectChanges();
+    tagElements = hostFixture.debugElement.queryAll(By.css('.tag'));
+
+    expect(tagElements[1].nativeElement.outerHTML).toContain(
+      'ng-reflect-removable="true"'
+    );
+    expect(tagElements[2].nativeElement.outerHTML).toContain(
+      'ng-reflect-removable="true"'
+    );
+  });
+
+  it('(.tag) should be removable if is first but `disableRemovingFirstTag` is falsy', () => {
+    let tagElements: DebugElement[];
+
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3']);
+    component.disableRemovingFirstTag = false;
+    hostFixture.detectChanges();
+    tagElements = hostFixture.debugElement.queryAll(By.css('.tag'));
+
+    expect(tagElements[0].nativeElement.outerHTML).toContain(
+      'ng-reflect-removable="true"'
+    );
+  });
+
+  it('(.tag) should NOT be removable if is first and `disableRemovingFirstTag` is truthy', () => {
+    let tagElements: DebugElement[];
+
+    component.tagsControl.setValue(['tag1', 'tag2', 'tag3']);
+    component.disableRemovingFirstTag = true;
+    hostFixture.detectChanges();
+    tagElements = hostFixture.debugElement.queryAll(By.css('.tag'));
+
+    expect(tagElements[0].nativeElement.outerHTML).toContain(
+      'ng-reflect-removable="false"'
+    );
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.tags__error--required) should be rendered and display correct message if `tagsControl` does have `required` error and it is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors({ required: true });
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--required')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.required
+    );
+  });
+
+  it('(.tags__error--required) should NOT be rendered if `tagsControl` doesn NOT have `required` error', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors(null);
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--required')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.tags__error--hash) should be rendered and display correct message if `tagsControl` does have `hash` error and it is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors({ hash: true });
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(By.css('.tags__error--hash'));
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.hash
+    );
+  });
+
+  it('(.tags__error--hash) should NOT be rendered if `tagsControl` doesn NOT have `hash` error', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors(null);
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(By.css('.tags__error--hash'));
+
+    expect(errorElement).toEqual(null);
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.tags__error--whitespace) should be rendered and display correct message if `tagsControl` does have `whitespace` error and it is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors({ whitespace: true });
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--whitespace')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.whitespace
+    );
+  });
+
+  it('(.tags__error--whitespace) should NOT be rendered if `tagsControl` doesn NOT have `whitespace` error', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors(null);
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--whitespace')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.tags__error--captial-letters) should be rendered and display correct message if `tagsControl` does have `capitalLetters` error and it is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors({ capitalLetters: true });
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--capital-letters')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.capitalLetters
+    );
+  });
+
+  it('(.tags__error--capital-letters) should NOT be rendered if `tagsControl` doesn NOT have `capitalLetters` error', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors(null);
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--capital-letters')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.tags__error--not-unique) should be rendered and display correct message if `tagsControl` does have `notUnique` error and it is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors({ notUnique: true });
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--not-unique')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.notUnique
+    );
+  });
+
+  it('(.tags__error--not-unique) should NOT be rendered if `tagsControl` doesn NOT have `notUnique` error', () => {
+    let errorElement: DebugElement;
+
+    component.tagsControl.setErrors(null);
+    component.tagsControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.tags__error--not-unique')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+});

--- a/src/app/editor/components/tags-partial-form/tags-partial-form.component.ts
+++ b/src/app/editor/components/tags-partial-form/tags-partial-form.component.ts
@@ -1,0 +1,70 @@
+import { COMMA, ENTER, SPACE } from '@angular/cdk/keycodes';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { MatChipInputEvent } from '@angular/material/chips';
+import { append, equals, filter, lt, remove, test } from 'ramda';
+
+@Component({
+  selector: 'app-tags-partial-form',
+  templateUrl: './tags-partial-form.component.html',
+  styleUrls: ['./tags-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TagsPartialFormComponent {
+  @Input() parentForm: FormGroup;
+  @Input() disableRemovingFirstTag = false;
+
+  readonly separatorKeysCodes: number[] = [ENTER, COMMA, SPACE];
+  readonly errorMessages = {
+    required: 'Please add at least one tag!',
+    hash: 'Tags cannot contain a # symbol!',
+    capitalLetters: 'Tags cannot contain capital letters!',
+    whitespace: 'Tags cannot contain whitespaces!',
+    notUnique: 'Tags cannot be repeated!'
+  };
+
+  get tagsControl(): AbstractControl {
+    return this.parentForm.get('tags');
+  }
+
+  addTag(event: MatChipInputEvent): void {
+    const tagsInput = event.input;
+    const newTag = event.value;
+    const tagsControl = this.parentForm.get('tags');
+    const currentTags = tagsControl.value;
+
+    if ((newTag || '').trim()) {
+      tagsControl.setValue(append(newTag.trim(), currentTags));
+    }
+
+    // Reset the input value
+    if (tagsInput) {
+      tagsInput.value = '';
+    }
+
+    this.tagsControl.markAsDirty();
+  }
+
+  removeTag(tag: string): void {
+    const index = this.parentForm.get('tags').value.indexOf(tag);
+    const tagsControl = this.parentForm.get('tags');
+    const currentTags = tagsControl.value;
+
+    if (index >= 0) {
+      tagsControl.setValue(remove(index, 1, currentTags));
+    }
+
+    this.tagsControl.markAsDirty();
+  }
+
+  isTagRemovable(i: number): boolean {
+    return this.disableRemovingFirstTag ? i !== 0 : true;
+  }
+
+  isValidTag(tag: string): boolean {
+    return (
+      test(/^[^#\sA-Z]+$/, tag) &&
+      lt(filter(equals(tag), this.tagsControl.value).length, 2)
+    );
+  }
+}

--- a/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.html
+++ b/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.html
@@ -1,0 +1,20 @@
+<mat-card>
+
+  <div [formGroup]="parentForm">
+    <mat-form-field class="custom-thumbnail__field">
+      <input matInput [errorStateMatcher]="onDirtyMatcher" formControlName="thumbnailUrl" type="url" placeholder="URL to a custom thumbnail"
+        class="custom-thumbnail__input">
+      <mat-error *ngIf="thumbnailUrlControl.hasError('pattern')" class="custom-thumbnail__error custom-thumbnail__error--pattern">{{ errorMessages.pattern }}</mat-error>
+    </mat-form-field>
+  </div>
+
+  <div *ngIf="currentThumbnailURL && thumbnailUrlControl.valid" class="current-thumbnail">
+    <mat-card-header>
+      <mat-card-title>
+        <span class="mat-title">Current thumbnail:</span>
+      </mat-card-title>
+    </mat-card-header>
+    <img mat-card-image [src]="currentThumbnailURL" alt="Thumbnail" class="current-thumbnail__image">
+  </div>
+
+</mat-card>

--- a/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.scss
+++ b/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.scss
@@ -1,0 +1,3 @@
+.custom-thumbnail__field {
+  width: 100%;
+}

--- a/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.spec.ts
+++ b/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.spec.ts
@@ -1,0 +1,157 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewChild,
+  DebugElement
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EditorMaterialModule } from '../../editor-material/editor-material.module';
+import { ThumbnailPartialFormComponent } from './thumbnail-partial-form.component';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  selector: `app-host-component`,
+  template: `<app-thumbnail-partial-form [parentForm]="parentForm"></app-thumbnail-partial-form>`
+})
+class TestHostComponent {
+  @ViewChild(ThumbnailPartialFormComponent)
+  thumbnailPartialFormComponent: ThumbnailPartialFormComponent;
+
+  parentForm: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      body: ['', Validators.required],
+      thumbnailUrl: [
+        '',
+        Validators.pattern(
+          // tslint:disable-next-line:max-line-length
+          /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})/
+        )
+      ]
+    });
+  }
+}
+
+fdescribe('#EditorModule ThumbnailPartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: ThumbnailPartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, ThumbnailPartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(ThumbnailPartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.thumbnailPartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#bodyControl should be pointing on `parentForm.controls.body`', () => {
+    expect(component.bodyControl).toBe(component.parentForm.controls.body);
+  });
+
+  it('#thumbnailUrlControl should be pointing on `parentForm.controls.thumbnailUrl`', () => {
+    expect(component.thumbnailUrlControl).toBe(
+      component.parentForm.controls.thumbnailUrl
+    );
+  });
+
+  it('#currentThumbnailURL should be equal to `thumbnailUrlControl.value` if it is NOT empty', () => {
+    component.thumbnailUrlControl.setValue(
+      'https://imagesimgipfssuper.ipfs/12345/'
+    );
+
+    expect(component.currentThumbnailURL).toEqual(
+      'https://imagesimgipfssuper.ipfs/12345/'
+    );
+  });
+
+  it('#currentThumbnailURL should be taken from `bodyControl.value` if it is has any images', () => {
+    component.bodyControl.setValue(
+      'test test ![](https://imagesimgipfssuper.ipfs/12345/)'
+    );
+
+    expect(component.currentThumbnailURL).toEqual(
+      'https://imagesimgipfssuper.ipfs/12345/'
+    );
+  });
+
+  it('#currentThumbnailURL should favor thumbnail from `thumbnailUrlControl` not `bodyControl`', () => {
+    component.thumbnailUrlControl.setValue(
+      'https://imagesimgipfssuper.ipfs/thumbnailUrlControl/'
+    );
+    component.bodyControl.setValue(
+      'test test ![](https://imagesimgipfssuper.ipfs/bodyControl/)'
+    );
+
+    expect(component.currentThumbnailURL).toEqual(
+      'https://imagesimgipfssuper.ipfs/thumbnailUrlControl/'
+    );
+  });
+
+  it('#currentThumbnailURL should be equal null if neither `thumbnailUrlControl` nor `bodyControl` have thumbnail inside', () => {
+    component.thumbnailUrlControl.setValue('');
+    component.bodyControl.setValue('test test');
+
+    expect(component.currentThumbnailURL).toEqual(null);
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.custom-thumbnail__error--pattern) should be rendered and display correct message if `thumbnailUrlControl` has `pattern` error and it is dirty', () => {
+    let errorElement: DebugElement;
+
+    component.thumbnailUrlControl.setErrors({ pattern: true });
+    component.thumbnailUrlControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.custom-thumbnail__error--pattern')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.pattern
+    );
+  });
+
+  // tslint:disable-next-line:max-line-length
+  it('(.custom-thumbnail__error--pattern) should NOT be rendered if `thumbnailUrlControl` doesn NOT have `pattern` error', () => {
+    let errorElement: DebugElement;
+
+    component.thumbnailUrlControl.setErrors(null);
+    component.thumbnailUrlControl.markAsDirty();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.custom-thumbnail__error--pattern')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+});

--- a/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.ts
+++ b/src/app/editor/components/thumbnail-partial-form/thumbnail-partial-form.component.ts
@@ -1,0 +1,73 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnDestroy,
+  OnInit
+} from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
+import {
+  always,
+  compose,
+  either,
+  head,
+  identity,
+  ifElse,
+  isEmpty,
+  isNil
+} from 'ramda';
+import { Subscription } from 'rxjs';
+import { getImages } from './../../../../core/steemize/withJsonMetadata';
+
+@Component({
+  selector: 'app-thumbnail-partial-form',
+  templateUrl: './thumbnail-partial-form.component.html',
+  styleUrls: ['./thumbnail-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ThumbnailPartialFormComponent implements OnInit, OnDestroy {
+  @Input() parentForm: FormGroup;
+
+  currentThumbnailURL: string | null;
+  onDirtyMatcher = new ShowOnDirtyErrorStateMatcher();
+
+  readonly errorMessages = {
+    pattern: 'Please enter a valid URL!'
+  };
+
+  private parentFormChangesSubscription: Subscription;
+
+  get bodyControl(): AbstractControl {
+    return this.parentForm.get('body');
+  }
+
+  get thumbnailUrlControl(): AbstractControl {
+    return this.parentForm.get('thumbnailUrl');
+  }
+
+  ngOnInit() {
+    this.parentFormChangesSubscription = this.parentForm.valueChanges.subscribe(
+      () => {
+        this.currentThumbnailURL = this.getCurrentThumbnailURL();
+      }
+    );
+  }
+
+  ngOnDestroy() {
+    this.parentFormChangesSubscription.unsubscribe();
+  }
+
+  private getCurrentThumbnailURL(): string | null {
+    return ifElse(
+      either(isNil, isEmpty),
+      () =>
+        compose(
+          ifElse(either(isNil, isEmpty), always(null), identity),
+          ifElse(either(isNil, isEmpty), always(''), head),
+          getImages
+        )(this.bodyControl.value),
+      identity
+    )(this.thumbnailUrlControl.value);
+  }
+}

--- a/src/app/editor/components/title-partial-form/title-partial-form.component.html
+++ b/src/app/editor/components/title-partial-form/title-partial-form.component.html
@@ -1,0 +1,6 @@
+<div [formGroup]="parentForm">
+  <mat-form-field class="title__field">
+    <input matInput formControlName="title" type="text" placeholder="Title">
+    <mat-error *ngIf="titleControl.hasError('required')" class="title__error title__error--required">{{ errorMessages.required }}</mat-error>
+  </mat-form-field>
+</div>

--- a/src/app/editor/components/title-partial-form/title-partial-form.component.scss
+++ b/src/app/editor/components/title-partial-form/title-partial-form.component.scss
@@ -1,0 +1,3 @@
+.title__field {
+  width: 100%;
+}

--- a/src/app/editor/components/title-partial-form/title-partial-form.component.spec.ts
+++ b/src/app/editor/components/title-partial-form/title-partial-form.component.spec.ts
@@ -1,0 +1,101 @@
+import {
+  Component,
+  ViewChild,
+  ChangeDetectionStrategy,
+  DebugElement
+} from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+  ReactiveFormsModule
+} from '@angular/forms';
+import { TitlePartialFormComponent } from './title-partial-form.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EditorMaterialModule } from '../../editor-material/editor-material.module';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  selector: `app-host-component`,
+  template: `<app-title-partial-form [parentForm]="parentForm"></app-title-partial-form>`
+})
+class TestHostComponent {
+  @ViewChild(TitlePartialFormComponent)
+  titlePartialFormComponent: TitlePartialFormComponent;
+
+  parentForm: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.parentForm = this.formBuilder.group({
+      title: ['', Validators.required]
+    });
+  }
+}
+
+fdescribe('#EditorModule TitlePartialFormComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let component: TitlePartialFormComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserAnimationsModule,
+        ReactiveFormsModule,
+        EditorMaterialModule
+      ],
+      declarations: [TestHostComponent, TitlePartialFormComponent]
+    })
+      // `OnPush` change detection lets run change detection manually only once,
+      // that's why for tests `Default` change detection has to be set
+      .overrideComponent(TitlePartialFormComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    component = hostComponent.titlePartialFormComponent;
+
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#titleControl should be pointing on `parentForm.controls.title`', () => {
+    expect(component.titleControl).toBe(component.parentForm.controls.title);
+  });
+
+  it('(.title__error--required) should be rendered and display correct message if `titleControl` has `required` err and is touched', () => {
+    let errorElement: DebugElement;
+
+    component.titleControl.setErrors({ required: true });
+    component.titleControl.markAsTouched();
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.title__error--required')
+    );
+
+    expect(errorElement.nativeElement).toBeDefined();
+    expect(errorElement.nativeElement.innerText).toContain(
+      component.errorMessages.required
+    );
+  });
+
+  it('(.title__error--required) should NOT be rendered if `titleControl` doesn NOT have `required` error', () => {
+    let errorElement: DebugElement;
+
+    component.titleControl.setErrors(null);
+    hostFixture.detectChanges();
+    errorElement = hostFixture.debugElement.query(
+      By.css('.title__error--required')
+    );
+
+    expect(errorElement).toEqual(null);
+  });
+});

--- a/src/app/editor/components/title-partial-form/title-partial-form.component.ts
+++ b/src/app/editor/components/title-partial-form/title-partial-form.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-title-partial-form',
+  templateUrl: './title-partial-form.component.html',
+  styleUrls: ['./title-partial-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TitlePartialFormComponent {
+  @Input() parentForm: FormGroup;
+
+  readonly errorMessages = {
+    required: 'Title cannot be empty!'
+  };
+
+  get titleControl(): AbstractControl {
+    return this.parentForm.get('title');
+  }
+}

--- a/src/app/editor/editor-material/editor-material.module.spec.ts
+++ b/src/app/editor/editor-material/editor-material.module.spec.ts
@@ -1,0 +1,13 @@
+import { EditorMaterialModule } from './editor-material.module';
+
+describe('EditorMaterialModule', () => {
+  let editorMaterialModule: EditorMaterialModule;
+
+  beforeEach(() => {
+    editorMaterialModule = new EditorMaterialModule();
+  });
+
+  it('should create an instance', () => {
+    expect(editorMaterialModule).toBeTruthy();
+  });
+});

--- a/src/app/editor/editor-material/editor-material.module.ts
+++ b/src/app/editor/editor-material/editor-material.module.ts
@@ -1,0 +1,38 @@
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatStepperModule } from '@angular/material/stepper';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+const MATERIAL_MODULES = [
+  MatButtonModule,
+  MatCardModule,
+  MatChipsModule,
+  MatDividerModule,
+  MatExpansionModule,
+  MatFormFieldModule,
+  MatIconModule,
+  MatInputModule,
+  MatSlideToggleModule,
+  MatSliderModule,
+  MatStepperModule,
+  MatTabsModule,
+  MatToolbarModule,
+  MatTooltipModule
+];
+
+@NgModule({
+  imports: MATERIAL_MODULES,
+  exports: MATERIAL_MODULES
+})
+export class EditorMaterialModule {}

--- a/src/app/editor/editor.module.spec.ts
+++ b/src/app/editor/editor.module.spec.ts
@@ -1,0 +1,13 @@
+import { EditorModule } from './editor.module';
+
+fdescribe('EditorModule', () => {
+  let editorModule: EditorModule;
+
+  beforeEach(() => {
+    editorModule = new EditorModule();
+  });
+
+  it('should create an instance', () => {
+    expect(editorModule).toBeTruthy();
+  });
+});

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MarkdownModule } from 'ngx-markdown';
+import { BeneficiariesPartialFormComponent } from './components/beneficiaries-partial-form/beneficiaries-partial-form.component';
+import { BodyPartialFormComponent } from './components/body-partial-form/body-partial-form.component';
+import { CommunityPartialFormComponent } from './components/community-partial-form/community-partial-form.component';
+import { EditorComponent } from './components/editor/editor.component';
+import { JsonMetadataPartialFormComponent } from './components/json-metadata-partial-form/json-metadata-partial-form.component';
+import { OptionsPartialFormComponent } from './components/options-partial-form/options-partial-form.component';
+import { PostPreviewComponent } from './components/post-preview/post-preview.component';
+import { TagsPartialFormComponent } from './components/tags-partial-form/tags-partial-form.component';
+import { ThumbnailPartialFormComponent } from './components/thumbnail-partial-form/thumbnail-partial-form.component';
+import { TitlePartialFormComponent } from './components/title-partial-form/title-partial-form.component';
+import { EditorMaterialModule } from './editor-material/editor-material.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    EditorMaterialModule,
+    FlexLayoutModule,
+    MarkdownModule.forChild()
+  ],
+  declarations: [
+    EditorComponent,
+    ThumbnailPartialFormComponent,
+    TagsPartialFormComponent,
+    CommunityPartialFormComponent,
+    TitlePartialFormComponent,
+    BodyPartialFormComponent,
+    PostPreviewComponent,
+    OptionsPartialFormComponent,
+    JsonMetadataPartialFormComponent,
+    BeneficiariesPartialFormComponent
+  ],
+  exports: [EditorComponent]
+})
+export class EditorModule {}

--- a/src/app/editor/index.ts
+++ b/src/app/editor/index.ts
@@ -1,0 +1,3 @@
+export { EditorModule } from './editor.module';
+export { EditorComponent } from './components/editor/editor.component';
+export { EditorConfig, createEditorConfig } from './components/editor/config';

--- a/src/app/editor/matchers/always.matcher.spec.ts
+++ b/src/app/editor/matchers/always.matcher.spec.ts
@@ -1,0 +1,30 @@
+import { FormControl } from '@angular/forms';
+import { AlwaysMatcher } from './always.matcher';
+
+fdescribe('#EditorModule AlwaysMatcher', () => {
+  let matcher: AlwaysMatcher;
+  let testControl: FormControl;
+
+  beforeEach(() => {
+    matcher = new AlwaysMatcher();
+    testControl = new FormControl();
+  });
+
+  it('should match error when control is invalid', () => {
+    let isErrorMatched: boolean;
+
+    testControl.setErrors({ testError: true });
+    isErrorMatched = matcher.isErrorState(testControl, null);
+
+    expect(isErrorMatched).toBeTruthy();
+  });
+
+  it('should NOT match error when control is valid', () => {
+    let isErrorMatched: boolean;
+
+    testControl.setErrors(null);
+    isErrorMatched = matcher.isErrorState(testControl, null);
+
+    expect(isErrorMatched).toBeFalsy();
+  });
+});

--- a/src/app/editor/matchers/always.matcher.ts
+++ b/src/app/editor/matchers/always.matcher.ts
@@ -1,0 +1,14 @@
+import { ErrorStateMatcher } from '@angular/material/core';
+import { FormControl, FormGroupDirective, NgForm } from '@angular/forms';
+
+/**
+ * Matches error always when control is invalid.
+ */
+export class AlwaysMatcher implements ErrorStateMatcher {
+  isErrorState(
+    control: FormControl | null,
+    form: FormGroupDirective | NgForm | null
+  ): boolean {
+    return !!(control && control.invalid);
+  }
+}

--- a/src/app/editor/validators/beneficiaries.validators.spec.ts
+++ b/src/app/editor/validators/beneficiaries.validators.spec.ts
@@ -1,0 +1,213 @@
+import {
+  validateWeightSum,
+  validateQuantity,
+  validateUniqueNames
+} from './beneficiaries.validators';
+import { FormArray, FormGroup, FormControl } from '@angular/forms';
+
+fdescribe('#EditorModule `beneficiaries` field custom validators', () => {
+  fdescribe('validateWeightSum', () => {
+    it('should return null if sum of beneficiaries weights is less than 100', () => {
+      const beneficiariesArray = new FormArray([
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(30)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-dev'),
+          weight: new FormControl(40)
+        })
+      ]);
+
+      const result = validateWeightSum(beneficiariesArray);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return an object with `tooHighWeight` property equal true if sum of beneficiaries weights is greater than 100', () => {
+      const beneficiariesArray = new FormArray([
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(30)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-dev'),
+          weight: new FormControl(40)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-pl'),
+          weight: new FormControl(40)
+        })
+      ]);
+
+      const result = validateWeightSum(beneficiariesArray);
+
+      expect(result).toEqual({ tooHighWeight: true });
+    });
+  });
+
+  fdescribe('validateQuantity', () => {
+    it('should return null if number of beneficiaries is lower of equal 8', () => {
+      const beneficiariesArray = new FormArray([
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('noisy'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('jacekw'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('rafalski'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('fervi'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('saunter'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-dev'),
+          weight: new FormControl(1)
+        })
+      ]);
+
+      const resultWith7 = validateQuantity(beneficiariesArray);
+      expect(resultWith7).toEqual(null);
+
+      beneficiariesArray.push(
+        new FormGroup({
+          account: new FormControl('mkcafe'),
+          weight: new FormControl(1)
+        })
+      );
+      const resultWith8 = validateQuantity(beneficiariesArray);
+      expect(resultWith8).toEqual(null);
+    });
+
+    it('should return an object with `tooManyBeneficiaries` property equal true if there are more than 8 beneficiaries', () => {
+      const beneficiariesArray = new FormArray([
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('noisy'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('jacekw'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('rafalski'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('fervi'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('saunter'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('mkcafe'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('nicniezgrublem'),
+          weight: new FormControl(1)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-dev'),
+          weight: new FormControl(1)
+        })
+      ]);
+
+      const result = validateQuantity(beneficiariesArray);
+
+      expect(result).toEqual({ tooManyBeneficiaries: true });
+    });
+  });
+
+  fdescribe('validateUniqueNames', () => {
+    it('should return null if all beneficiaries names are unique', () => {
+      const beneficiariesArray = new FormArray([
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(30)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-dev'),
+          weight: new FormControl(40)
+        }),
+        new FormGroup({
+          account: new FormControl('mkcafe'),
+          weight: new FormControl(10)
+        })
+      ]);
+
+      const result = validateUniqueNames(beneficiariesArray);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should ignore controls with empty `account` property in their value', () => {
+      const beneficiariesArray = new FormArray([
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(30)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-dev'),
+          weight: new FormControl(40)
+        }),
+        new FormGroup({
+          account: new FormControl(''),
+          weight: new FormControl(10)
+        }),
+        new FormGroup({
+          account: new FormControl(''),
+          weight: new FormControl(10)
+        }),
+        new FormGroup({
+          account: new FormControl(''),
+          weight: new FormControl(10)
+        })
+      ]);
+
+      const result = validateUniqueNames(beneficiariesArray);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return an object with `notUniqueNames` property equal true if not all names are unique', () => {
+      const beneficiariesArray = new FormArray([
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(30)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk-dev'),
+          weight: new FormControl(40)
+        }),
+        new FormGroup({
+          account: new FormControl('jakipatryk'),
+          weight: new FormControl(10)
+        })
+      ]);
+
+      const result = validateUniqueNames(beneficiariesArray);
+
+      expect(result).toEqual({ notUniqueNames: true });
+    });
+  });
+});

--- a/src/app/editor/validators/beneficiaries.validators.ts
+++ b/src/app/editor/validators/beneficiaries.validators.ts
@@ -1,0 +1,51 @@
+import { AbstractControl } from '@angular/forms';
+import {
+  add,
+  always,
+  equals,
+  ifElse,
+  isEmpty,
+  lt,
+  map,
+  path,
+  pipe,
+  prop,
+  reduce,
+  reject,
+  uniq
+} from 'ramda';
+
+export const validateWeightSum: (
+  beneficiariesFormArray: AbstractControl
+) => null | { tooHighWeight: true } = pipe(
+  prop('value'),
+  map((beneficiary: { account: string; weight: number }) => beneficiary.weight),
+  reduce(add, 0),
+  ifElse(lt(100), always({ tooHighWeight: true }), always(null))
+);
+
+export const validateQuantity: (
+  beneficiariesFormArray: AbstractControl
+) => null | { tooManyBeneficiaries: true } = pipe(
+  path(['value', 'length']),
+  ifElse(lt(8), always({ tooManyBeneficiaries: true }), always(null))
+);
+
+export const validateUniqueNames: (
+  beneficiariesFormArray: AbstractControl
+) => null | { notUniqueNames: true } = pipe(
+  prop('value'),
+  map(prop('account')),
+  reject(isEmpty),
+  beneficiaries => ({ original: beneficiaries, unique: uniq(beneficiaries) }),
+  beneficiariesObj =>
+    equals(beneficiariesObj.original, beneficiariesObj.unique)
+      ? null
+      : { notUniqueNames: true }
+);
+
+export const beneficiariesCustomValidators = [
+  validateWeightSum,
+  validateQuantity,
+  validateUniqueNames
+];

--- a/src/app/editor/validators/json-metadata.validators.spec.ts
+++ b/src/app/editor/validators/json-metadata.validators.spec.ts
@@ -1,0 +1,30 @@
+import { FormControl } from '@angular/forms';
+import { validateJSON } from './json-metadata.validators';
+
+fdescribe('#EditorModule `jsonMetadata` field custom validators', () => {
+  fdescribe('validateJSON', () => {
+    it('should return null if control value is a valid JSON', () => {
+      const control = new FormControl('{"app":"steeditor/0.1.0"}');
+
+      const result = validateJSON(control);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return null if control value is an empty string', () => {
+      const control = new FormControl('');
+
+      const result = validateJSON(control);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return object with `invalidJson` property equal true if control value is NOT a valid JSON', () => {
+      const control = new FormControl('invalid json');
+
+      const result = validateJSON(control);
+
+      expect(result).toEqual({ invalidJson: true });
+    });
+  });
+});

--- a/src/app/editor/validators/json-metadata.validators.ts
+++ b/src/app/editor/validators/json-metadata.validators.ts
@@ -1,0 +1,16 @@
+import { AbstractControl } from '@angular/forms';
+import { always, ifElse, pipe, prop, isEmpty } from 'ramda';
+import { isJsonValid } from './../../../core/utils';
+
+export const validateJSON: (
+  control: AbstractControl
+) => null | { invalidJson: true } = pipe(
+  prop('value'),
+  ifElse(
+    isJsonValid,
+    always(null),
+    ifElse(isEmpty, always(null), always({ invalidJson: true }))
+  )
+);
+
+export const jsonMetadataCustomValidators = [validateJSON];

--- a/src/app/editor/validators/tags.validators.spec.ts
+++ b/src/app/editor/validators/tags.validators.spec.ts
@@ -1,0 +1,106 @@
+import {
+  validateNoCapitalLetters,
+  validateNoHashes,
+  validateNoWhitespaces,
+  validateUnique
+} from './tags.validators';
+import { FormControl } from '@angular/forms';
+
+fdescribe('#EditorModule `tags` field custom validators', () => {
+  fdescribe('validateNoCapitalLetters', () => {
+    it('should return null if the control value does NOT contain capital letters', () => {
+      const controlWithoutCapitalLetters = new FormControl([
+        'tag1',
+        'tag2',
+        'tag-3',
+        'tag4'
+      ]);
+
+      const result = validateNoCapitalLetters(controlWithoutCapitalLetters);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return an object with `capitalLetters` property equal true if any tag contain capital letters', () => {
+      const controlWithOnlyCapitalLetters = new FormControl([
+        'TAG',
+        'TAGG',
+        'TAGGG',
+        'TAGGGG'
+      ]);
+      const controlWithSomeCapitalLetters = new FormControl([
+        'tag1',
+        'tAg2',
+        'Tag3'
+      ]);
+
+      const resultOnlyCapitalLetters = validateNoCapitalLetters(
+        controlWithOnlyCapitalLetters
+      );
+      const resultSomeCaptialLetters = validateNoCapitalLetters(
+        controlWithSomeCapitalLetters
+      );
+
+      expect(resultOnlyCapitalLetters).toEqual({ capitalLetters: true });
+      expect(resultSomeCaptialLetters).toEqual({ capitalLetters: true });
+    });
+  });
+
+  fdescribe('validateNoHashes', () => {
+    it('should return null if the control value does NOT contain any hashes', () => {
+      const controlWihoutHashes = new FormControl(['tag1', 'tag2', 'tag3']);
+
+      const result = validateNoHashes(controlWihoutHashes);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return an object with `hash` property equal true if there are any hashes in the tags', () => {
+      const controlWithHashes = new FormControl(['#tag1', '#tag2', 'tag3']);
+
+      const result = validateNoHashes(controlWithHashes);
+
+      expect(result).toEqual({ hash: true });
+    });
+  });
+
+  fdescribe('validateNoWhitespaces', () => {
+    it('should return null if there are no whitespaces in tags', () => {
+      const controlWithoutWhitespaces = new FormControl([
+        'tag1',
+        'tag2',
+        'tag3'
+      ]);
+
+      const result = validateNoWhitespaces(controlWithoutWhitespaces);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return an object with `whitespace` property equal true if there are any whitespaces in tags', () => {
+      const controlWithSpaces = new FormControl(['tag 1', 'tag 2', 'tag3']);
+
+      const result = validateNoWhitespaces(controlWithSpaces);
+
+      expect(result).toEqual({ whitespace: true });
+    });
+  });
+
+  fdescribe('validateUnique', () => {
+    it('should return null if all tags from form control are unique', () => {
+      const controlUnique = new FormControl(['tag1', 'tag2', 'tag3']);
+
+      const result = validateUnique(controlUnique);
+
+      expect(result).toEqual(null);
+    });
+
+    it('should return an object with `notUnique` property equal true if tags are not unique', () => {
+      const controlNotUnique = new FormControl(['tag1', 'tag2', 'tag1']);
+
+      const result = validateUnique(controlNotUnique);
+
+      expect(result).toEqual({ notUnique: true });
+    });
+  });
+});

--- a/src/app/editor/validators/tags.validators.ts
+++ b/src/app/editor/validators/tags.validators.ts
@@ -1,0 +1,43 @@
+import { AbstractControl } from '@angular/forms';
+import { compose, ifElse, all, test, always, prop, uniq, equals } from 'ramda';
+
+export const validateNoCapitalLetters: (
+  control: AbstractControl
+) => null | { capitalLetters: true } = compose(
+  ifElse(
+    all(test(/^[^A-Z]+$/)),
+    always(null),
+    always({ capitalLetters: true })
+  ),
+  prop('value')
+);
+
+export const validateNoHashes: (
+  control: AbstractControl
+) => null | { hash: true } = compose(
+  ifElse(all(test(/^[^#]+$/)), always(null), always({ hash: true })),
+  prop('value')
+);
+
+export const validateNoWhitespaces: (
+  control: AbstractControl
+) => null | { whitespace: true } = compose(
+  ifElse(all(test(/^[^\s]+$/)), always(null), always({ whitespace: true })),
+  prop('value')
+);
+
+export const validateUnique: (
+  control: AbstractControl
+) => null | { notUnique: true } = compose(
+  tagsObj =>
+    equals(tagsObj.original, tagsObj.unique) ? null : { notUnique: true },
+  tags => ({ original: tags, unique: uniq(tags) }),
+  prop('value')
+);
+
+export const tagsCustomValidators = [
+  validateNoCapitalLetters,
+  validateNoHashes,
+  validateNoWhitespaces,
+  validateUnique
+];


### PR DESCRIPTION
- added `EditorModule` with one public component: `EditorComponent`

### Reusability

Editor will be used in a few other modules in the future, that's why I have also created a `EditorConfig` interface and `createEditorConfig` pure function, what makes `EditorComponent` very reusable.

### Brand new

Almost everything has been made from scratch. Editor is now much more user friendly an powerfull. Ability to specify a community where a post should belong to has been added, and post preview, and current metadata preview, etc.

### Flexibility

`EditorModule` has only one public component, that's one reason why it is easy to extend without affecting public API.

### Screenshots

![screen1](https://user-images.githubusercontent.com/18032838/42973292-f07a4a68-8bb2-11e8-9bfc-cf18dcbb9d08.png)
![screen2](https://user-images.githubusercontent.com/18032838/42973338-227cddfa-8bb3-11e8-8e37-a33f08f700dc.png)
![screen3](https://user-images.githubusercontent.com/18032838/42973418-5e4b44d4-8bb3-11e8-824d-ccb07e46afec.png)
![screen4](https://user-images.githubusercontent.com/18032838/42973472-8fb4a010-8bb3-11e8-9544-58af40dbd06e.png)



