### PR TITLE
fix(editor): community should be optional

### DIFF
--- a/src/app/editor/components/community-partial-form/community-partial-form.component.html
+++ b/src/app/editor/components/community-partial-form/community-partial-form.component.html
@@ -1,7 +1,6 @@
 <div [formGroup]="parentForm">
   <mat-form-field class="community__field">
     <input matInput [errorStateMatcher]="onDirtyMatcher" formControlName="community" type="text" placeholder="Community" class="community__input">
-    <mat-error *ngIf="communityControl.hasError('required')" class="community__error community__error--required">{{ errorMessages.required }}</mat-error>
     <mat-error *ngIf="communityControl.hasError('pattern')" class="community__error community__error--pattern">{{ errorMessages.pattern }}</mat-error>
   </mat-form-field>
 </div>

--- a/src/app/editor/components/community-partial-form/community-partial-form.component.spec.ts
+++ b/src/app/editor/components/community-partial-form/community-partial-form.component.spec.ts
@@ -74,35 +74,6 @@ fdescribe('#EditorModule CommunityPartialFormComponent', () => {
   });
 
   // tslint:disable-next-line:max-line-length
-  it('(.community__error--required) should be rendered if `communityControl` has `required` error and is dirty + should contain correct message', () => {
-    let communityErrorRequiredElement: DebugElement;
-
-    component.communityControl.setErrors({ required: true });
-    component.communityControl.markAsDirty();
-    hostFixture.detectChanges();
-    communityErrorRequiredElement = hostFixture.debugElement.query(
-      By.css('.community__error--required')
-    );
-
-    expect(communityErrorRequiredElement.nativeElement).toBeDefined();
-    expect(communityErrorRequiredElement.nativeElement.innerText).toContain(
-      component.errorMessages.required
-    );
-  });
-
-  it('(.community__error--required) should NOT be rendered if `communityControl` does NOT have `required` error', () => {
-    let communityErrorRequiredElement: DebugElement;
-
-    component.communityControl.setErrors(null);
-    hostFixture.detectChanges();
-    communityErrorRequiredElement = hostFixture.debugElement.query(
-      By.css('.community__error--required')
-    );
-
-    expect(communityErrorRequiredElement).toEqual(null);
-  });
-
-  // tslint:disable-next-line:max-line-length
   it('(.community__error--pattern) should be rendered if `communityControl` has `pattern` error and is dirty + should contain correct message', () => {
     let communityErrorPatternElement: DebugElement;
 

--- a/src/app/editor/components/community-partial-form/community-partial-form.component.ts
+++ b/src/app/editor/components/community-partial-form/community-partial-form.component.ts
@@ -14,7 +14,6 @@ export class CommunityPartialFormComponent {
   onDirtyMatcher = new ShowOnDirtyErrorStateMatcher();
 
   readonly errorMessages = {
-    required: 'Community cannot be empty!',
     pattern: 'Community can only contain lower case letters!'
   };
 

--- a/src/app/editor/components/editor/editor.component.html
+++ b/src/app/editor/components/editor/editor.component.html
@@ -2,7 +2,7 @@
 
   <mat-step [stepControl]="contentForm">
     <form [formGroup]="contentForm">
-      <ng-template matStepLabel>Fill out required fields</ng-template>
+      <ng-template matStepLabel>Write Post</ng-template>
 
       <app-title-partial-form [parentForm]="contentForm"></app-title-partial-form>
 

--- a/src/app/editor/components/editor/editor.component.ts
+++ b/src/app/editor/components/editor/editor.component.ts
@@ -115,7 +115,7 @@ export class EditorComponent implements OnInit, OnDestroy {
           value: communityFieldConfig.value,
           disabled: communityFieldConfig.disabled
         },
-        [Validators.required, Validators.pattern(/^[a-z]+$/)]
+        [Validators.pattern(/^[a-z]+$/)]
       ],
       tags: [
         { value: tagsFieldConfig.value, disabled: tagsFieldConfig.disabled },


### PR DESCRIPTION
Fix #37:
- [x] Remove Validators.required
- [x] Change text on the label into something that does not contain a word "required"
- [x] Remove error hint
- [x] Remove error message from the class
- [x] Remove specs